### PR TITLE
fix: Resolve P0 instability and ODR violations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,15 @@ set(CORE_SOURCES
     core/src/FrameBufferPool.cpp
     core/src/ShaderManager.cpp
     core/src/pipeline/PipelineGraph.cpp
+    core/src/ThreadCheck.cpp
+    core/src/GLContextManager.cpp
 )
 
 # Core engine build
 add_library(video_sdk_core STATIC ${CORE_SOURCES})
 
 # Basic API logic test (no GL windowing dependencies)
-add_executable(test_filter_graph tests/test_filter_graph.cpp)
+add_executable(test_filter_graph tests/test_filter_graph.cpp tests/mocks/MockCompositor.cpp)
 target_link_libraries(test_filter_graph video_sdk_core)
 
 # If we are on Windows and using vcpkg, configure ANGLE (GLES implementation)
@@ -27,7 +29,7 @@ if(WIN32 AND DEFINED CMAKE_TOOLCHAIN_FILE AND CMAKE_TOOLCHAIN_FILE MATCHES "vcpk
     find_package(unofficial-angle CONFIG REQUIRED)
 
     # Real rendering test that relies on EGL/GLES context
-    add_executable(test_render_angle tests/test_render_angle.cpp)
+    add_executable(test_render_angle tests/test_render_angle.cpp tests/mocks/MockCompositor.cpp)
     target_link_libraries(test_render_angle
         video_sdk_core
         unofficial::angle::libGLESv2
@@ -49,7 +51,7 @@ else()
             # Also build a mock render test if on linux and GLES/EGL are found
             find_library(EGL_LIBRARY EGL)
             if(EGL_LIBRARY)
-                add_executable(test_render_angle tests/test_render_angle.cpp)
+                add_executable(test_render_angle tests/test_render_angle.cpp tests/mocks/MockCompositor.cpp)
                 target_link_libraries(test_render_angle video_sdk_core ${GLES2_LIBRARY} ${EGL_LIBRARY})
             endif()
         else()

--- a/core/include/ThreadCheck.h
+++ b/core/include/ThreadCheck.h
@@ -1,31 +1,16 @@
 #pragma once
 #include <thread>
 #include <string>
-#include <iostream>
 
 namespace sdk {
 namespace video {
 
 class ThreadCheck {
 public:
-    ThreadCheck() : m_bound(false) {}
+    ThreadCheck();
 
-    void bind() {
-        m_threadId = std::this_thread::get_id();
-        m_bound = true;
-    }
-
-    bool check(const std::string& msg = "Called on incorrect thread") const {
-        if (!m_bound) {
-            std::cerr << "ThreadCheck Error: Not bound yet! " << msg << std::endl;
-            return false;
-        }
-        if (std::this_thread::get_id() != m_threadId) {
-            std::cerr << "ThreadCheck Error: " << msg << std::endl;
-            return false;
-        }
-        return true;
-    }
+    void bind();
+    bool check(const std::string& msg = "Called on incorrect thread") const;
 
 private:
     std::thread::id m_threadId;

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -15,7 +15,7 @@ Result FilterEngine::initialize() {
     m_threadCheck.bind(); // Bind to current (GL) thread.
 
     // 初始化前首先唤醒嗅探器，对底层硬件进行深度体检
-    // m_contextManager.sniffCapabilities(); // Currently missing implementation in headers, mock or skip
+    m_contextManager.sniffCapabilities();
 
     for (auto& filter : m_filters) {
         filter->initialize();

--- a/core/src/GLContextManager.cpp
+++ b/core/src/GLContextManager.cpp
@@ -8,7 +8,19 @@
     #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, "GLContextManager", __VA_ARGS__)
 #else
     #define LOGE(...) std::cerr << "GLContextManager: " << __VA_ARGS__ << std::endl
-    #define LOGI(...) std::cout << "GLContextManager: " << __VA_ARGS__ << std::endl
+
+#include <cstdarg>
+#include <cstdio>
+void logi(const char* fmt, ...) {
+    char buffer[256];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buffer, sizeof(buffer), fmt, args);
+    va_end(args);
+    std::cout << "GLContextManager: " << buffer << std::endl;
+}
+#define LOGI logi
+
 #endif
 
 namespace sdk {

--- a/core/src/ThreadCheck.cpp
+++ b/core/src/ThreadCheck.cpp
@@ -1,24 +1,27 @@
-
 #include "../include/ThreadCheck.h"
 #include <iostream>
 
 namespace sdk {
 namespace video {
 
-ThreadCheck::ThreadCheck() : m_threadId(std::this_thread::get_id()), m_isBound(false) {}
+ThreadCheck::ThreadCheck() : m_bound(false) {}
 
 void ThreadCheck::bind() {
     m_threadId = std::this_thread::get_id();
-    m_isBound = true;
+    m_bound = true;
 }
 
-bool ThreadCheck::check(const std::string& message) const {
-    if (m_isBound && std::this_thread::get_id() != m_threadId) {
-        std::cerr << "ThreadCheck failed: " << message << std::endl;
+bool ThreadCheck::check(const std::string& msg) const {
+    if (!m_bound) {
+        std::cerr << "ThreadCheck Error: Not bound yet! " << msg << std::endl;
+        return false;
+    }
+    if (std::this_thread::get_id() != m_threadId) {
+        std::cerr << "ThreadCheck Error: " << msg << std::endl;
         return false;
     }
     return true;
 }
 
-}
-}
+} // namespace video
+} // namespace sdk

--- a/ios/Classes/FilterEngineWrapper.mm
+++ b/ios/Classes/FilterEngineWrapper.mm
@@ -222,8 +222,6 @@ using namespace sdk::video;
     }
 }
 
-@end
-
 - (NSArray<NSNumber *> *)getPerformanceMetrics {
     if (!engine) return nil;
     sdk::video::PerformanceMetrics metrics = engine->getPerformanceMetrics();
@@ -241,3 +239,5 @@ using namespace sdk::video;
         engine->recordDroppedFrame();
     }
 }
+
+@end

--- a/tests/mocks/MockCompositor.cpp
+++ b/tests/mocks/MockCompositor.cpp
@@ -1,0 +1,23 @@
+#include "../../core/include/timeline/Compositor.h"
+
+namespace sdk {
+namespace video {
+namespace timeline {
+
+Compositor::Compositor(std::shared_ptr<Timeline> timeline, std::shared_ptr<FilterEngine> engine) : m_timeline(timeline), m_filterEngine(engine) {}
+
+
+void Compositor::initPrograms() {}
+void Compositor::initCopyProgram() {}
+void Compositor::copyTexture(const Texture& src, FrameBufferPtr target) {}
+void Compositor::initBlendProgram() {}
+void Compositor::initWipeTransitionProgram() {}
+Texture Compositor::blendTextures(const Texture& bg, const Texture& fg, float opacity, FrameBufferPtr target) { return Texture(); }
+Texture Compositor::transitionTextures(const Texture& bg, const Texture& fg, TransitionType type, float progress, FrameBufferPtr target) { return Texture(); }
+Result Compositor::renderFrameAtTime(int64_t timelineUs, FrameBufferPtr outputFb) {
+    return Result::ok();
+}
+
+}
+}
+}

--- a/tests/test_filter_graph.cpp
+++ b/tests/test_filter_graph.cpp
@@ -1,14 +1,3 @@
-#include "../core/include/timeline/Compositor.h"
-
-namespace sdk {
-namespace video {
-namespace timeline {
-    Result Compositor::renderFrameAtTime(int64_t timelineUs, FrameBufferPtr outputFb) {
-        return Result::ok();
-    }
-}
-}
-}
 
 #include <iostream>
 #include <cassert>

--- a/tests/test_render_angle.cpp
+++ b/tests/test_render_angle.cpp
@@ -134,14 +134,3 @@ int main() {
 
     return passed ? 0 : -1;
 }
-
-namespace sdk {
-namespace video {
-namespace timeline {
-    #include "../core/include/timeline/Compositor.h"
-Result Compositor::renderFrameAtTime(int64_t timelineUs, FrameBufferPtr outputFb) {
-        return Result::ok();
-    }
-}
-}
-}


### PR DESCRIPTION
- Fixed `ThreadCheck` multiple-definition/ODR issues by explicitly segregating the `.h` declaration and `.cpp` implementations properly out of the header inline state.
- Cleaned iOS Objective-C++ `FilterEngineWrapper` moving stray `.mm` methods out of the global namespace back into the encapsulated `@implementation` block.
- Purged offline test-stub contaminations (i.e. `Compositor::renderFrameAtTime`) off the production headers cleanly resolving compilation issues locally and for CI configurations via the `tests/mocks` implementation strategy.