### PR TITLE
Fix CI node 20 deprecations, iOS build destination, and Android build…

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,16 +16,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
 
       - name: Generate Gradle Wrapper
-        working-directory: ./android
+        working-directory: ./
         run: gradle wrapper
 
       - name: Build with Gradle
-        working-directory: ./android
+        working-directory: ./
         run: ./gradlew assembleDebug --stacktrace

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -29,4 +29,4 @@ jobs:
         run: |
           cd ios
           # We use xcodebuild with a minimal project now
-          xcodebuild clean build -project "VideoSDK.xcodeproj" -scheme "VideoSDK" -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+          xcodebuild clean build -project "VideoSDK.xcodeproj" -scheme "VideoSDK" -destination "generic/platform=iOS Simulator" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO


### PR DESCRIPTION
… directory

- Use `actions/setup-java@v4` and `actions/checkout@v4` across workflows.
- Fix Android CI where `gradle wrapper` and `./gradlew` was failing because the `working-directory` was set to `./android` but the top-level project is now at `./` with `sample-android`.
- Fix iOS CI where `xcodebuild` failed finding the `platform=iOS Simulator,name=iPhone 15,OS=latest` destination by using `generic/platform=iOS Simulator` instead.