### PR TITLE
Fix JNI reflection caching and rendering matrix dynamic allocations

### DIFF
--- a/android/src/main/cpp/NativeBridge.cpp
+++ b/android/src/main/cpp/NativeBridge.cpp
@@ -147,10 +147,17 @@ struct EngineWrapper {
 };
 
 
+static jfieldID g_lastFrameTimeMsId = nullptr;
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL
 Java_com_sdk_video_RenderEngine_nativeInit(JNIEnv *env, jobject thiz, jobject assetManager) {
+    if (!g_lastFrameTimeMsId) {
+        jclass cls = env->GetObjectClass(thiz);
+        g_lastFrameTimeMsId = env->GetFieldID(cls, "lastFrameTimeMs", "J");
+    }
+
     EngineWrapper* wrapper = new EngineWrapper();
     wrapper->filterEngine = std::make_shared<FilterEngine>();
 
@@ -188,10 +195,9 @@ Java_com_sdk_video_RenderEngine_nativeProcessFrame(JNIEnv *env, jobject thiz, jl
 
     jsize len = env->GetArrayLength(matrix);
     if (len == 16) {
-        jfloat *elements = env->GetFloatArrayElements(matrix, 0);
-        std::vector<float> textureMatrix(elements, elements + 16);
-        env->ReleaseFloatArrayElements(matrix, elements, 0);
-        wrapper->filterEngine->updateParameter("textureMatrix", std::any(textureMatrix));
+        jfloat buffer[16];
+        env->GetFloatArrayRegion(matrix, 0, 16, buffer);
+        wrapper->filterEngine->updateParameterMat4("textureMatrix", buffer);
     }
 
     Texture inTex = {static_cast<uint32_t>(textureId), static_cast<uint32_t>(width), static_cast<uint32_t>(height)};
@@ -210,10 +216,8 @@ Java_com_sdk_video_RenderEngine_nativeProcessFrame(JNIEnv *env, jobject thiz, jl
     auto end = std::chrono::high_resolution_clock::now();
     long long durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 
-    jclass cls = env->GetObjectClass(thiz);
-    jfieldID lastFrameTimeMsId = env->GetFieldID(cls, "lastFrameTimeMs", "J");
-    if (lastFrameTimeMsId) {
-        env->SetLongField(thiz, lastFrameTimeMsId, static_cast<jlong>(durationMs));
+    if (g_lastFrameTimeMsId) {
+        env->SetLongField(thiz, g_lastFrameTimeMsId, static_cast<jlong>(durationMs));
     }
 
     return outTex.id;

--- a/core/include/Filter.h
+++ b/core/include/Filter.h
@@ -31,6 +31,7 @@ public:
     virtual Texture processFrame(const Texture& inputTexture, FrameBufferPtr outputFb);
 
     virtual void setParameter(const std::string& key, const std::any& value);
+    virtual void setParameterMat4(const std::string& key, const float* matrix);
 
 protected:
     std::shared_ptr<ShaderManager> m_shaderManager;
@@ -47,6 +48,7 @@ protected:
 
     GLuint m_programId;
     std::map<std::string, std::any> m_parameters;
+    std::map<std::string, std::array<float, 16>> m_mat4Parameters;
 
     // Common attributes/uniforms
     GLuint m_positionHandle;

--- a/core/include/FilterEngine.h
+++ b/core/include/FilterEngine.h
@@ -34,6 +34,7 @@ public:
 
     // Update filter parameters
     void updateParameter(const std::string& key, const std::any& value);
+    void updateParameterMat4(const std::string& key, const float* matrix);
 
     // Release resources
     void release();

--- a/core/src/Filter.cpp
+++ b/core/src/Filter.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include "../include/Filter.h"
 #include <iostream>
 #include <cstdlib>
@@ -59,6 +60,14 @@ Texture Filter::processFrame(const Texture& inputTexture, FrameBufferPtr outputF
 
 void Filter::setParameter(const std::string& key, const std::any& value) {
     m_parameters[key] = value;
+}
+
+void Filter::setParameterMat4(const std::string& key, const float* matrix) {
+    if (matrix) {
+        std::array<float, 16> arr;
+        std::copy(matrix, matrix + 16, arr.begin());
+        m_mat4Parameters[key] = arr;
+    }
 }
 
 std::string Filter::getVertexShaderSource() const {

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -73,13 +73,22 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
 }
 
 void FilterEngine::updateParameter(const std::string& key, const std::any& value) {
-
-
     if (m_graph) {
         for (const auto& node : m_graph->getNodes()) {
             auto filterNode = std::dynamic_pointer_cast<FilterNode>(node);
             if (filterNode && filterNode->getFilter()) {
                 filterNode->getFilter()->setParameter(key, value);
+            }
+        }
+    }
+}
+
+void FilterEngine::updateParameterMat4(const std::string& key, const float* matrix) {
+    if (m_graph) {
+        for (const auto& node : m_graph->getNodes()) {
+            auto filterNode = std::dynamic_pointer_cast<FilterNode>(node);
+            if (filterNode && filterNode->getFilter()) {
+                filterNode->getFilter()->setParameterMat4(key, matrix);
             }
         }
     }

--- a/core/src/Filters.cpp
+++ b/core/src/Filters.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include "../include/Filters.h"
 #include <iostream>
 #include <vector>
@@ -127,7 +128,7 @@ static const float s_textureCoords[] = {
 
 OES2RGBFilter::OES2RGBFilter() {
     // Default to identity matrix
-    m_parameters["textureMatrix"] = std::vector<float>{
+    m_mat4Parameters["textureMatrix"] = std::array<float, 16>{
         1.0f, 0.0f, 0.0f, 0.0f,
         0.0f, 1.0f, 0.0f, 0.0f,
         0.0f, 0.0f, 1.0f, 0.0f,
@@ -168,11 +169,9 @@ void OES2RGBFilter::onDraw(const Texture& inputTexture, FrameBufferPtr outputFb)
     glBindTexture(GL_TEXTURE_EXTERNAL_OES, inputTexture.id); // Important: Use OES target
     glUniform1i(m_inputImageTextureHandle, 0);
 
-    if (m_parameters.count("textureMatrix") && m_parameters.at("textureMatrix").type() == typeid(std::vector<float>)) {
-        auto matrix = std::any_cast<std::vector<float>>(m_parameters.at("textureMatrix"));
-        if (matrix.size() == 16) {
-            glUniformMatrix4fv(m_textureMatrixHandle, 1, GL_FALSE, matrix.data());
-        }
+    if (m_mat4Parameters.count("textureMatrix")) {
+        auto& matrix = m_mat4Parameters.at("textureMatrix");
+        glUniformMatrix4fv(m_textureMatrixHandle, 1, GL_FALSE, matrix.data());
     }
 
     bool flipH = false;

--- a/core/src/timeline/AudioMixer.cpp
+++ b/core/src/timeline/AudioMixer.cpp
@@ -12,10 +12,10 @@ std::vector<int16_t> AudioMixer::mixAudioAtTime(int64_t timelineNs, int64_t dura
     if (!m_timeline || !m_decoderPool) return {};
 
     // Note: Assuming standard 44.1kHz, 2 channels (Stereo).
-    // Samples needed = (durationNs / 1,000,000) * 44100 * 2 channels.
+    // Samples needed = (durationNs / 1,000,000,000) * 44100 * 2 channels.
     const int SAMPLE_RATE = 44100;
     const int CHANNELS = 2;
-    size_t samplesNeeded = static_cast<size_t>((durationNs / 1000000.0) * SAMPLE_RATE * CHANNELS);
+    size_t samplesNeeded = static_cast<size_t>((durationNs / 1000000000.0) * SAMPLE_RATE * CHANNELS);
 
     // Safety check: Avoid huge allocations if duration is wrong
     if (samplesNeeded <= 0 || samplesNeeded > SAMPLE_RATE * CHANNELS * 5) {

--- a/core/src/timeline/TimelineExporterIOS.mm
+++ b/core/src/timeline/TimelineExporterIOS.mm
@@ -170,7 +170,7 @@ private:
                     glBindFramebuffer(GL_FRAMEBUFFER, 0);
                     glFinish(); // 确保渲染指令完成
 
-                    CMTime presentationTime = CMTimeMake(currentTimeNs, 1000000);
+                    CMTime presentationTime = CMTimeMake(currentTimeNs, 1000000000);
                     [adaptor appendPixelBuffer:pixelBuffer withPresentationTime:presentationTime];
 
                     CFRelease(cvTexture);


### PR DESCRIPTION
- Cached `lastFrameTimeMsId` in `nativeInit` avoiding JNI reflection lookup every frame via `GetObjectClass` + `GetFieldID`.
- Added zero-allocation array update method `setParameterMat4` to the Filter and FilterEngine C++ core.
- Prevented `std::any` boxing memory allocations on every frame for the 64-byte `std::array<float, 16>` structure by assigning to a dedicated `m_mat4Parameters`.
- Fixed CI Math regressions for iOS video exporting timestamps and AudioMixer duration.