### PR TITLE
Refactor Timeline timestamp unit to Ns, FilterEngine structure, and T…

### DIFF
--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -41,7 +41,10 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
     auto start_time = std::chrono::high_resolution_clock::now();
 
     if (m_isGraphDirty) {
-        buildCameraPipeline();
+        Result res = buildCameraPipeline();
+        if (!res.isOk()) {
+            return ResultPayload<Texture>::error(res.getErrorCode(), "Pipeline build failed: " + res.getMessage());
+        }
         m_isGraphDirty = false;
     }
 
@@ -210,6 +213,11 @@ Result FilterEngine::buildCameraPipeline() {
     }
 
     newGraph->connect(lastNode, m_outputNode);
+
+    // Explicitly release old graph to prevent memory leak and properly free FBOs/OpenGL state
+    if (m_graph) {
+        m_graph->release();
+    }
     m_graph = newGraph;
 
 
@@ -259,6 +267,11 @@ Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> t
     }
 
     newGraph->connect(lastNode, m_outputNode);
+
+    // Explicitly release old graph to prevent memory leak and properly free FBOs/OpenGL state
+    if (m_graph) {
+        m_graph->release();
+    }
     m_graph = newGraph;
 
 


### PR DESCRIPTION
…hread Safety

- Globally unified timeline timestamp scale from Microseconds (Us) to Nanoseconds (Ns) across all modules (Track, Clip, DecoderPool, AudioMixer, Compositor).
- Fortified `Timeline` with `std::shared_mutex` for read-write access to active track structures during JNI async UI updates.
- Refactored `FilterEngine` structural leaks:
  - Ensured prior PipelineGraph FBO and texture states are explicitly `released()` during a graph reconfiguration (e.g., `buildCameraPipeline`).
  - Switched public arrays/states (`m_frameBufferPool` access, obsolete `m_filters` lists, `m_simulateCrash`) safely behind strict encapsulation and the robust `PipelineNode` tree.
- Restored `Result` error payloads in hardware initializations, throwing detailed fallback status through Swift/Kotlin instead of silent C++ std::cerr logs.