### PR TITLE
🧪 [testing improvement] Add test for codec profile optimization failure in VideoEncoder.kt

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,4 +77,9 @@ dependencies {
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation 'androidx.test:core:1.5.0'
 }

--- a/android/src/test/java/com/sdk/video/VideoEncoderTest.kt
+++ b/android/src/test/java/com/sdk/video/VideoEncoderTest.kt
@@ -1,0 +1,47 @@
+package com.sdk.video
+
+import android.media.MediaCodecList
+import android.media.MediaFormat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class VideoEncoderTest {
+
+    @Test
+    fun testOptimizeCodecProfileFailure() {
+        // Mock VideoFilterManager and VideoExportConfig
+        val filterManager = mock(VideoFilterManager::class.java)
+        val config = VideoExportConfig(
+            width = 1280,
+            height = 720,
+            videoBitrate = 5000000,
+            fps = 30,
+            outputPath = "/sdcard/test.mp4"
+        )
+
+        val videoEncoder = VideoEncoder(filterManager, config)
+        val format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, 1280, 720)
+
+        // Use Mockito to mock MediaCodecList constructor to throw an exception
+        mockConstruction(MediaCodecList::class.java) { mock, context ->
+            throw RuntimeException("Simulated MediaCodecList failure")
+        }.use {
+            // Access the private method optimizeCodecProfileAndBitrateMode via reflection
+            val method = VideoEncoder::class.java.getDeclaredMethod(
+                "optimizeCodecProfileAndBitrateMode",
+                MediaFormat::class.java
+            )
+            method.isAccessible = true
+
+            // This should not throw an exception as it is caught inside VideoEncoder
+            method.invoke(videoEncoder, format)
+        }
+
+        // If we reached here without exception, the test passed
+    }
+}


### PR DESCRIPTION
Improved test coverage for VideoEncoder by adding a unit test that simulates hardware probing failures. This ensures the catch block in `optimizeCodecProfileAndBitrateMode` correctly prevents initialization crashes when MediaCodecList is unavailable or faulty.

---
*PR created automatically by Jules for task [10975996329073164479](https://jules.google.com/task/10975996329073164479) started by @zx2121651*