### PR TITLE
Fix orientation and cropping with SurfaceTexture transform order

### DIFF
--- a/core/src/Filters.cpp
+++ b/core/src/Filters.cpp
@@ -22,14 +22,14 @@ uniform bool flipVertical;
 out vec2 textureCoordinate;
 void main() {
     gl_Position = position;
-    // Apply SurfaceTexture transform matrix to fix orientation/cropping
-    vec2 coord = (textureMatrix * inputTextureCoordinate).xy;
 
-    // Apply manual flips if necessary
+    vec4 coord = inputTextureCoordinate;
+    // Apply manual flips if necessary BEFORE the matrix transform
     if (flipHorizontal) coord.x = 1.0 - coord.x;
     if (flipVertical) coord.y = 1.0 - coord.y;
 
-    textureCoordinate = coord;
+    // Apply SurfaceTexture transform matrix to fix orientation/cropping
+    textureCoordinate = (textureMatrix * coord).xy;
 }
 )";
 


### PR DESCRIPTION
This PR fixes an issue in the `OES2RGBFilter` where manual flips were applied after the `SurfaceTexture` transformation matrix. When the matrix encodes a rotation or non-centered crop, applying flips afterwards results in incorrect cropping and orientation.

Moving the flips before the matrix transformation ensures they are applied to the normalized [0, 1] coordinates, allowing the matrix to correctly map the flipped coordinates to the intended texture region.

---
*PR created automatically by Jules for task [17014928181815389001](https://jules.google.com/task/17014928181815389001) started by @zx2121651*