### PR TITLE
🧹 [code health] Deduplicate pipeline building logic in FilterEngine

### DIFF
--- a/core/include/FilterEngine.h
+++ b/core/include/FilterEngine.h
@@ -76,6 +76,8 @@ private:
 
     // 【三级防线】特征级嗅探器
     GLContextManager m_contextManager;
+
+    Result rebuildGraph(std::shared_ptr<PipelineNode> inputNode);
 };
 
 using FilterEnginePtr = std::shared_ptr<FilterEngine>;

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -170,67 +170,22 @@ void FilterEngine::updateShaderSource(const std::string& name, const std::string
 
 Result FilterEngine::buildCameraPipeline() {
     m_cameraNode = std::make_shared<CameraInputNode>("Camera");
-    m_outputNode = std::make_shared<OutputNode>("Display");
-
-    std::shared_ptr<PipelineNode> lastNode = m_cameraNode;
-
-    // Create new graph
-    auto newGraph = std::make_shared<PipelineGraph>();
-    newGraph->addNode(m_cameraNode);
-    newGraph->addNode(m_outputNode);
-
-    // Keep existing filters
-    if (m_graph) {
-        std::vector<std::shared_ptr<Filter>> rawFilters;
-        for (const auto& node : m_graph->getNodes()) {
-            if (auto filterNode = std::dynamic_pointer_cast<FilterNode>(node)) {
-                rawFilters.push_back(filterNode->getFilter());
-            }
-        }
-
-        // Properly release the old graph as instructed
-        m_graph->release();
-
-        for (size_t i = 0; i < rawFilters.size(); ++i) {
-            auto filterNode = std::make_shared<FilterNode>("Filter_" + std::to_string(i), rawFilters[i]);
-
-            FBOPrecision targetPrecision = FBOPrecision::RGBA8888;
-            bool isIntermediate = (i < rawFilters.size() - 1);
-            if (isIntermediate) {
-                if (m_contextManager.isFP16RenderTargetSupported()) {
-                    targetPrecision = FBOPrecision::FP16;
-                } else {
-                    targetPrecision = FBOPrecision::RGB565;
-                }
-            }
-            filterNode->setFrameBufferPool(&m_frameBufferPool);
-            filterNode->setTargetPrecision(targetPrecision);
-
-            newGraph->addNode(filterNode);
-            newGraph->connect(lastNode, filterNode);
-            lastNode = filterNode;
-        }
-    }
-
-    newGraph->connect(lastNode, m_outputNode);
-
-    m_graph = newGraph;
-
-
-    Result res = m_graph->compile();
-    if (!res.isOk()) { std::cerr << "Pipeline Compile Failed: " << res.getMessage() << std::endl; return res; }
-    return Result::ok();
+    return rebuildGraph(m_cameraNode);
 }
 
 Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> timeline, std::shared_ptr<timeline::Compositor> compositor) {
     auto timelineNode = std::make_shared<TimelineNode>("Timeline", timeline, compositor);
+    return rebuildGraph(timelineNode);
+}
+
+Result FilterEngine::rebuildGraph(std::shared_ptr<PipelineNode> inputNode) {
     m_outputNode = std::make_shared<OutputNode>("Display");
 
-    std::shared_ptr<PipelineNode> lastNode = timelineNode;
+    std::shared_ptr<PipelineNode> lastNode = inputNode;
 
     // Create new graph
     auto newGraph = std::make_shared<PipelineGraph>();
-    newGraph->addNode(timelineNode);
+    newGraph->addNode(inputNode);
     newGraph->addNode(m_outputNode);
 
     // Keep existing filters
@@ -270,9 +225,11 @@ Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> t
 
     m_graph = newGraph;
 
-
     Result res = m_graph->compile();
-    if (!res.isOk()) { std::cerr << "Pipeline Compile Failed: " << res.getMessage() << std::endl; return res; }
+    if (!res.isOk()) {
+        std::cerr << "Pipeline Compile Failed: " << res.getMessage() << std::endl;
+        return res;
+    }
     return Result::ok();
 }
 


### PR DESCRIPTION
🎯 **What:** Extracted duplicated pipeline building logic from `buildCameraPipeline` and `buildTimelinePipeline` into a private helper method `rebuildGraph`.
💡 **Why:** Improves maintainability and readability by following the DRY principle and centralizing graph construction logic.
✅ **Verification:** Verified with existing tests `test_filter_graph` and `test_timeline`.
✨ **Result:** Reduced code duplication in `FilterEngine.cpp` and simplified the addition of new pipeline types.

---
*PR created automatically by Jules for task [13218340298530184511](https://jules.google.com/task/13218340298530184511) started by @zx2121651*