### PR TITLE
Fix OES transform and Android/iOS CI build failures

### DIFF
--- a/ios/Classes/VideoFilterManager.swift
+++ b/ios/Classes/VideoFilterManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreVideo
 import OpenGLES
+import AVFoundation
 
 // 定义支持的视频滤镜类型枚举
 public enum VideoFilterType: Int {

--- a/ios/Classes/VideoSDK-Bridging-Header.h
+++ b/ios/Classes/VideoSDK-Bridging-Header.h
@@ -1,0 +1,6 @@
+#ifndef VideoSDK_Bridging_Header_h
+#define VideoSDK_Bridging_Header_h
+
+#import "FilterEngineWrapper.h"
+
+#endif /* VideoSDK_Bridging_Header_h */

--- a/ios/VideoSDK.xcodeproj/project.pbxproj
+++ b/ios/VideoSDK.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 				SWIFT_VERSION = 5.0;
                 HEADER_SEARCH_PATHS = "$(SRCROOT)/../core/include";
                 GENERATE_INFOPLIST_FILE = YES;
+                SWIFT_OBJC_BRIDGING_HEADER = Classes/VideoSDK-Bridging-Header.h;
 			};
 			name = Debug;
 		};
@@ -170,6 +171,7 @@
 				SWIFT_VERSION = 5.0;
                 HEADER_SEARCH_PATHS = "$(SRCROOT)/../core/include";
                 GENERATE_INFOPLIST_FILE = YES;
+                SWIFT_OBJC_BRIDGING_HEADER = Classes/VideoSDK-Bridging-Header.h;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This PR addresses several issues:
1. Fixed OES shader logic to apply flips before the transformation matrix, ensuring correct cropping/orientation.
2. Fixed Android CI by reverting Gradle version from 9.4.1 (which has breaking changes) to 8.8.
3. Fixed iOS CI build failures:
   - Enabled `GENERATE_INFOPLIST_FILE`.
   - Created and configured a bridging header so Swift can find `FilterEngineWrapper`.
   - Imported `AVFoundation` in `VideoFilterManager.swift` for `CMTime` and `CMSampleBuffer` support.

---
*PR created automatically by Jules for task [17014928181815389001](https://jules.google.com/task/17014928181815389001) started by @zx2121651*