### PR TITLE
Upgrade test_timeline to behavioral validation

### DIFF
--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -1,34 +1,172 @@
 #include <iostream>
 #include <cassert>
 #include <memory>
+#include <vector>
+#include <cmath>
 #include "../core/include/timeline/Timeline.h"
 #include "../core/include/timeline/Track.h"
 #include "../core/include/timeline/Clip.h"
 
 using namespace sdk::video::timeline;
 
-void test_timeline_creation() {
+// Use a small epsilon for float comparisons
+const float EPSILON = 1e-5f;
+
+void test_timeline_basic_properties() {
     auto timeline = std::make_shared<Timeline>(1920, 1080, 30);
     assert(timeline->getOutputWidth() == 1920);
     assert(timeline->getOutputHeight() == 1080);
+    assert(timeline->getFps() == 30);
+    std::cout << "test_timeline_basic_properties passed" << std::endl;
+}
 
-    timeline->addTrack(0, Track::TrackType::MAIN_VIDEO);
-    auto track = timeline->getTrack(0);
-    assert(track != nullptr);
+void test_sequential_clips_and_gaps() {
+    auto timeline = std::make_shared<Timeline>(1920, 1080, 30);
+    auto track = timeline->addTrack(0, Track::TrackType::MAIN_VIDEO);
 
-    auto clip = std::make_shared<Clip>("clip_1", "path/to/video.mp4", Clip::MediaType::VIDEO);
+    // Clip 1: 0s to 2s
+    auto clip1 = std::make_shared<Clip>("clip_1", "v1.mp4", Clip::MediaType::VIDEO);
+    clip1->setTimelineIn(0);
+    clip1->setTrimIn(0);
+    clip1->setTrimOut(2000000000); // 2s
+    track->addClip(clip1);
+
+    // Gap: 2s to 3s
+
+    // Clip 2: 3s to 5s
+    auto clip2 = std::make_shared<Clip>("clip_2", "v2.mp4", Clip::MediaType::VIDEO);
+    clip2->setTimelineIn(3000000000); // 3s
+    clip2->setTrimIn(0);
+    clip2->setTrimOut(2000000000); // 2s
+    track->addClip(clip2);
+
+    // Assertions
+    assert(track->getActiveClipAtTime(1000000000)->getId() == "clip_1"); // 1s
+    assert(track->getActiveClipAtTime(2000000000) == nullptr);           // 2s (End is exclusive)
+    assert(track->getActiveClipAtTime(2500000000) == nullptr);           // 2.5s (Gap)
+    assert(track->getActiveClipAtTime(3000000000)->getId() == "clip_2"); // 3s
+    assert(track->getActiveClipAtTime(4000000000)->getId() == "clip_2"); // 4s
+    assert(track->getActiveClipAtTime(5000000000) == nullptr);           // 5s
+
+    std::cout << "test_sequential_clips_and_gaps passed" << std::endl;
+}
+
+void test_multi_track_activation() {
+    auto timeline = std::make_shared<Timeline>(1920, 1080, 30);
+    auto mainTrack = timeline->addTrack(0, Track::TrackType::MAIN_VIDEO);
+    auto pipTrack = timeline->addTrack(10, Track::TrackType::PIP_VIDEO);
+
+    // Main clip: 0s to 5s
+    auto mainClip = std::make_shared<Clip>("main", "main.mp4", Clip::MediaType::VIDEO);
+    mainClip->setTimelineIn(0);
+    mainClip->setTrimOut(5000000000);
+    mainTrack->addClip(mainClip);
+
+    // PIP clip: 1s to 3s
+    auto pipClip = std::make_shared<Clip>("pip", "pip.mp4", Clip::MediaType::VIDEO);
+    pipClip->setTimelineIn(1000000000);
+    pipClip->setTrimOut(2000000000);
+    pipTrack->addClip(pipClip);
+
+    std::vector<ClipPtr> activeClips;
+
+    // At 0.5s: only main
+    timeline->getActiveVideoClipsAtTime(500000000, activeClips);
+    assert(activeClips.size() == 1);
+    assert(activeClips[0]->getId() == "main");
+
+    // At 2s: both main and pip
+    timeline->getActiveVideoClipsAtTime(2000000000, activeClips);
+    assert(activeClips.size() == 2);
+    assert(activeClips[0]->getId() == "main");
+    assert(activeClips[1]->getId() == "pip");
+
+    // At 4s: only main
+    timeline->getActiveVideoClipsAtTime(4000000000, activeClips);
+    assert(activeClips.size() == 1);
+    assert(activeClips[0]->getId() == "main");
+
+    std::cout << "test_multi_track_activation passed" << std::endl;
+}
+
+void test_transition_properties() {
+    auto clip = std::make_shared<Clip>("clip", "v.mp4", Clip::MediaType::VIDEO);
+
+    // Default should be NONE
+    assert(clip->getInTransitionType() == TransitionType::NONE);
+    assert(clip->getInTransitionDurationNs() == 0);
+
+    clip->setInTransition(TransitionType::WIPE_LEFT, 500000000); // 0.5s
+    assert(clip->getInTransitionType() == TransitionType::WIPE_LEFT);
+    assert(clip->getInTransitionDurationNs() == 500000000);
+
+    std::cout << "test_transition_properties passed" << std::endl;
+}
+
+void test_duration_and_speed() {
+    auto timeline = std::make_shared<Timeline>(1920, 1080, 30);
+    auto track = timeline->addTrack(0, Track::TrackType::MAIN_VIDEO);
+
+    // Clip: 0s to 4s in timeline (but 2x speed, so 8s source used)
+    auto clip = std::make_shared<Clip>("clip", "v.mp4", Clip::MediaType::VIDEO);
     clip->setTimelineIn(0);
-    clip->setTrimOut(5000000000); // 5 seconds
+    clip->setTrimIn(0);
+    clip->setTrimOut(8000000000); // 8s
+    clip->setSpeed(2.0f);
     track->addClip(clip);
 
-    auto activeClip = track->getActiveClipAtTime(1000000000); // 1 second
-    assert(activeClip != nullptr);
-    assert(activeClip->getId() == "clip_1");
+    // Timeline duration should be 8s / 2.0 = 4s
+    assert(clip->getTimelineOut() == 4000000000);
+    assert(timeline->getTotalDuration() == 4000000000);
 
-    std::cout << "test_timeline_creation passed" << std::endl;
+    // Add another clip at 5s
+    auto clip2 = std::make_shared<Clip>("clip2", "v2.mp4", Clip::MediaType::VIDEO);
+    clip2->setTimelineIn(5000000000); // 5s
+    clip2->setTrimIn(0);
+    clip2->setTrimOut(1000000000); // 1s
+    clip2->setSpeed(0.5f); // 0.5x speed
+    track->addClip(clip2);
+
+    // Clip2 timeline duration = 1s / 0.5 = 2s. TimelineOut = 5s + 2s = 7s.
+    assert(clip2->getTimelineOut() == 7000000000);
+    assert(timeline->getTotalDuration() == 7000000000);
+
+    std::cout << "test_duration_and_speed passed" << std::endl;
+}
+
+void test_keyframe_interpolation() {
+    auto clip = std::make_shared<Clip>("clip", "v.mp4", Clip::MediaType::VIDEO);
+
+    // Default opacity should be 1.0
+    assert(std::abs(clip->getOpacity(0) - 1.0f) < EPSILON);
+
+    // Add keyframes for opacity: 0.0 at 0s, 1.0 at 1s, 0.5 at 2s
+    clip->addKeyframe("opacity", 0, 0.0f);
+    clip->addKeyframe("opacity", 1000000000, 1.0f);
+    clip->addKeyframe("opacity", 2000000000, 0.5f);
+
+    // Test values at keyframes
+    assert(std::abs(clip->getOpacity(0) - 0.0f) < EPSILON);
+    assert(std::abs(clip->getOpacity(1000000000) - 1.0f) < EPSILON);
+    assert(std::abs(clip->getOpacity(2000000000) - 0.5f) < EPSILON);
+
+    // Test interpolated values
+    assert(std::abs(clip->getOpacity(500000000) - 0.5f) < EPSILON);  // halfway between 0s and 1s
+    assert(std::abs(clip->getOpacity(1500000000) - 0.75f) < EPSILON); // halfway between 1s and 2s
+
+    // Test out of bounds
+    assert(std::abs(clip->getOpacity(-1000) - 0.0f) < EPSILON);      // clamped to first
+    assert(std::abs(clip->getOpacity(3000000000) - 0.5f) < EPSILON); // clamped to last
+
+    std::cout << "test_keyframe_interpolation passed" << std::endl;
 }
 
 int main() {
-    test_timeline_creation();
+    test_timeline_basic_properties();
+    test_sequential_clips_and_gaps();
+    test_multi_track_activation();
+    test_transition_properties();
+    test_duration_and_speed();
+    test_keyframe_interpolation();
     return 0;
 }


### PR DESCRIPTION
Upgraded the `test_timeline` from a simple object creation smoke test to a comprehensive behavioral validation suite. The new tests cover multi-clip scenarios, multi-track activation, transition properties, speed-adjusted timeline duration, and keyframe interpolation. All tests have been verified to pass in a clean build environment.

Fixes #70

---
*PR created automatically by Jules for task [3175083658920194887](https://jules.google.com/task/3175083658920194887) started by @zx2121651*