### PR TITLE
Make FilterEngine::processFrame failure handling explicit

### DIFF
--- a/core/include/Filter.h
+++ b/core/include/Filter.h
@@ -28,7 +28,7 @@ public:
     virtual void release();
 
     // Renders the input texture to an output framebuffer and returns the output texture.
-    virtual Texture processFrame(const Texture& inputTexture, FrameBufferPtr outputFb);
+    virtual ResultPayload<Texture> processFrame(const Texture& inputTexture, FrameBufferPtr outputFb);
 
     virtual void setParameter(const std::string& key, const std::any& value);
     virtual void setParameterMat4(const std::string& key, const float* matrix);

--- a/core/include/Filters.h
+++ b/core/include/Filters.h
@@ -59,7 +59,7 @@ public:
     void onProgramRecompiled() override;
 
     // 重写 processFrame 因为双趟渲染不只是一次 onDraw
-    Texture processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) override;
+    ResultPayload<Texture> processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) override;
 
 protected:
     void onDraw(const Texture& inputTexture, FrameBufferPtr outputFb) override;
@@ -153,7 +153,7 @@ public:
     void initialize() override;
 
     // Compute Shader 不需要 Vertex 和 Fragment Shader
-    Texture processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) override;
+    ResultPayload<Texture> processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) override;
 
 protected:
     void onDraw(const Texture& inputTexture, FrameBufferPtr outputFb) override;

--- a/core/include/pipeline/Nodes.h
+++ b/core/include/pipeline/Nodes.h
@@ -18,10 +18,13 @@ public:
         m_latestFrame = frame;
     }
 
-    VideoFrame pullFrame(int64_t timestampNs) override {
+    ResultPayload<VideoFrame> pullFrame(int64_t timestampNs) override {
         std::lock_guard<std::mutex> lock(m_mutex);
         // Note: For advanced sync, we'd compare timestampNs to m_latestFrame.timestampNs
-        return m_latestFrame;
+        if (!m_latestFrame.isValid()) {
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "CameraInputNode has no valid frame");
+        }
+        return ResultPayload<VideoFrame>::ok(m_latestFrame);
     }
 
 private:
@@ -44,12 +47,22 @@ public:
         if (m_filter) m_filter->release();
     }
 
-    VideoFrame pullFrame(int64_t timestampNs) override {
-        if (m_inputs.empty() || !m_filter) return VideoFrame();
+    ResultPayload<VideoFrame> pullFrame(int64_t timestampNs) override {
+        if (m_inputs.empty()) {
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterNode has no input");
+        }
+        if (!m_filter) {
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterNode has no filter");
+        }
 
         // Pull from upstream
-        VideoFrame upstreamFrame = m_inputs[0]->pullFrame(timestampNs);
-        if (!upstreamFrame.isValid()) return upstreamFrame;
+        auto upstreamRes = m_inputs[0]->pullFrame(timestampNs);
+        if (!upstreamRes.isOk()) return upstreamRes;
+
+        VideoFrame upstreamFrame = upstreamRes.getValue();
+        if (!upstreamFrame.isValid()) {
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Upstream produced an invalid frame");
+        }
 
         Texture texIn{upstreamFrame.textureId, upstreamFrame.width, upstreamFrame.height};
 
@@ -59,7 +72,11 @@ public:
             fbo = m_pool->getFrameBuffer(upstreamFrame.width, upstreamFrame.height, m_targetPrecision);
         }
 
-        Texture texOut = m_filter->processFrame(texIn, fbo);
+        auto processRes = m_filter->processFrame(texIn, fbo);
+        if (!processRes.isOk()) {
+            return ResultPayload<VideoFrame>::error(processRes.getErrorCode(), processRes.getMessage());
+        }
+        Texture texOut = processRes.getValue();
 
         VideoFrame outFrame;
         outFrame.textureId = texOut.id;
@@ -70,7 +87,7 @@ public:
         // Retain the FBO so it is returned to the pool only when this VideoFrame is destroyed
         outFrame.frameBuffer = fbo;
 
-        return outFrame;
+        return ResultPayload<VideoFrame>::ok(outFrame);
     }
 
     void setFrameBufferPool(FrameBufferPool* pool) { m_pool = pool; }
@@ -87,11 +104,16 @@ class OutputNode : public PipelineNode {
 public:
     OutputNode(const std::string& name) : PipelineNode(name) {}
 
-    VideoFrame pullFrame(int64_t timestampNs) override {
-        if (m_inputs.empty()) return VideoFrame();
+    ResultPayload<VideoFrame> pullFrame(int64_t timestampNs) override {
+        if (m_inputs.empty()) {
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "OutputNode has no input");
+        }
 
-        m_lastFrame = m_inputs[0]->pullFrame(timestampNs);
-        return m_lastFrame;
+        auto res = m_inputs[0]->pullFrame(timestampNs);
+        if (res.isOk()) {
+            m_lastFrame = res.getValue();
+        }
+        return res;
     }
 
     VideoFrame getLastFrame() const { return m_lastFrame; }

--- a/core/include/pipeline/PipelineNode.h
+++ b/core/include/pipeline/PipelineNode.h
@@ -28,7 +28,7 @@ public:
 
     // Pull-model: Requests a frame for a given timestamp
     // Upstream nodes will evaluate and process recursively
-    virtual VideoFrame pullFrame(int64_t timestampNs) = 0;
+    virtual ResultPayload<VideoFrame> pullFrame(int64_t timestampNs) = 0;
 
     // Initialization hook (e.g., compiling shaders, allocating resources)
     virtual void initialize() {}

--- a/core/include/pipeline/TimelineNode.h
+++ b/core/include/pipeline/TimelineNode.h
@@ -12,8 +12,10 @@ public:
     TimelineNode(const std::string& name, std::shared_ptr<timeline::Timeline> timeline, std::shared_ptr<timeline::Compositor> compositor)
         : PipelineNode(name), m_timeline(timeline), m_compositor(compositor) {}
 
-    VideoFrame pullFrame(int64_t timestampNs) override {
-        if (!m_timeline || !m_compositor) return VideoFrame();
+    ResultPayload<VideoFrame> pullFrame(int64_t timestampNs) override {
+        if (!m_timeline || !m_compositor) {
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "TimelineNode not properly initialized");
+        }
 
         // Convert ns to ms or internal timeline units
         int64_t timeNs = timestampNs;
@@ -22,18 +24,23 @@ public:
         int height = m_timeline->getOutputHeight();
 
         FrameBufferPtr fbo = m_frameBufferPool.getFrameBuffer(width, height);
+        if (!fbo) {
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED, "Failed to allocate FBO for TimelineNode");
+        }
+
         Result res = m_compositor->renderFrameAtTime(timeNs, fbo);
+        if (!res.isOk()) {
+            return ResultPayload<VideoFrame>::error(res.getErrorCode(), res.getMessage());
+        }
 
         VideoFrame frame;
-        if (fbo) {
-            frame.textureId = fbo->getTexture().id;
-            frame.width = fbo->getTexture().width;
-            frame.height = fbo->getTexture().height;
-            frame.frameBuffer = fbo;
-        }
+        frame.textureId = fbo->getTexture().id;
+        frame.width = fbo->getTexture().width;
+        frame.height = fbo->getTexture().height;
+        frame.frameBuffer = fbo;
         frame.timestampNs = timestampNs;
 
-        return frame;
+        return ResultPayload<VideoFrame>::ok(frame);
     }
 
 private:

--- a/core/src/Filter.cpp
+++ b/core/src/Filter.cpp
@@ -43,19 +43,17 @@ void Filter::release() {
     }
 }
 
-Texture Filter::processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) {
+ResultPayload<Texture> Filter::processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) {
     if (m_programId == 0) {
-        std::cerr << "Filter not initialized or program invalid." << std::endl;
-        return inputTexture; // Passthrough if error
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Filter not initialized or program invalid.");
     }
 
     if (!outputFb) {
-        std::cerr << "Output framebuffer is null." << std::endl;
-        return inputTexture;
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Output framebuffer is null.");
     }
 
     onDraw(inputTexture, outputFb);
-    return outputFb->getTexture();
+    return ResultPayload<Texture>::ok(outputFb->getTexture());
 }
 
 void Filter::setParameter(const std::string& key, const std::any& value) {

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -74,7 +74,7 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
         m_metricsCollector.recordFrameTime(duration_ms);
 
         if (!outFrame.isValid()) {
-            return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Pipeline executed but produced an invalid output texture");
+            return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Pipeline produced an invalid output frame (missing texture)");
         }
         return ResultPayload<Texture>::ok(Texture{outFrame.textureId, outFrame.width, outFrame.height});
     }

--- a/core/src/Filters.cpp
+++ b/core/src/Filters.cpp
@@ -275,11 +275,21 @@ void GaussianBlurFilter::onProgramRecompiled() {
     m_texelHeightOffsetHandle = glGetUniformLocation(m_programId, "texelHeightOffset");
     m_blurSizeHandle = glGetUniformLocation(m_programId, "blurSize");
 }
-Texture GaussianBlurFilter::processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) {
-    if (!m_pool) return inputTexture;
+ResultPayload<Texture> GaussianBlurFilter::processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) {
+    if (!m_pool) {
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FrameBufferPool is null in GaussianBlurFilter");
+    }
 
     // 从 FBO 池中借用一个与输入尺寸一致的临时 FrameBuffer 用于存放第一趟（水平模糊）的结果
     FrameBufferPtr intermediateFb = m_pool->get(inputTexture.width, inputTexture.height);
+    if (!intermediateFb) {
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED, "Failed to allocate intermediate FBO for GaussianBlurFilter");
+    }
+
+    if (!outputFb) {
+        m_pool->release(intermediateFb);
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Output framebuffer is null in GaussianBlurFilter");
+    }
 
     // ---------------------------------------------------------
     // Pass 1: 水平模糊 (Horizontal Blur)
@@ -341,7 +351,7 @@ Texture GaussianBlurFilter::processFrame(const Texture& inputTexture, FrameBuffe
     // 释放临时 FBO，归还到池中
     m_pool->release(intermediateFb);
 
-    return outputFb->getTexture();
+    return ResultPayload<Texture>::ok(outputFb->getTexture());
 }
 
 void GaussianBlurFilter::onDraw(const Texture& inputTexture, FrameBufferPtr outputFb) {
@@ -635,8 +645,14 @@ void ComputeBlurFilter::initialize() {
     m_blurSizeHandle = glGetUniformLocation(m_computeProgramId, "blurSize");
 }
 
-Texture ComputeBlurFilter::processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) {
-    if (m_computeProgramId == 0) return inputTexture; // 兼容性失败时回退
+ResultPayload<Texture> ComputeBlurFilter::processFrame(const Texture& inputTexture, FrameBufferPtr outputFb) {
+    if (m_computeProgramId == 0) {
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "ComputeBlurFilter program not initialized");
+    }
+
+    if (!outputFb) {
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Output framebuffer is null in ComputeBlurFilter");
+    }
 
     // 我们不需要调用 FBO 的 bind() 来画三角形。
     // Compute Shader 直接对着内存中的 Texture 进行读写（Image Store）。
@@ -665,7 +681,7 @@ Texture ComputeBlurFilter::processFrame(const Texture& inputTexture, FrameBuffer
     // 设置内存屏障，确保在下次被当作纹理采样前，Compute Shader 的写入已经完全落盘到显存
     glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 
-    return outputFb->getTexture();
+    return ResultPayload<Texture>::ok(outputFb->getTexture());
 }
 
 void ComputeBlurFilter::onDraw(const Texture& inputTexture, FrameBufferPtr outputFb) {

--- a/core/src/pipeline/PipelineGraph.cpp
+++ b/core/src/pipeline/PipelineGraph.cpp
@@ -92,7 +92,10 @@ Result PipelineGraph::execute(int64_t timestampNs) {
 
     // In a pure pull model, we just ask the sinks to pull.
     for (auto* sink : m_sinkNodes) {
-        sink->pullFrame(timestampNs);
+        auto res = sink->pullFrame(timestampNs);
+        if (!res.isOk()) {
+            return Result::error(res.getErrorCode(), res.getMessage());
+        }
     }
 
     return Result::ok();

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -44,6 +44,8 @@ void test_lifecycle_functionality() {
 
     // Should fail gracefully because no GL context, but shouldn't crash
     auto res1 = engine.processFrame(inTex, 1920, 1080);
+    assert(!res1.isOk());
+
     // It should be ERR_RENDER_INVALID_STATE because glGetString(GL_VERSION) likely returns null without context
     // causing initialize or graph compile to fail, or just processFrame to fail.
 
@@ -55,6 +57,7 @@ void test_lifecycle_functionality() {
     engine.initialize();
     engine.addFilter(FilterType::BRIGHTNESS);
     auto res2 = engine.processFrame(inTex, 1920, 1080);
+    assert(!res2.isOk());
 
     // Check performance metrics (should be cleared on release)
     PerformanceMetrics metrics = engine.getPerformanceMetrics();


### PR DESCRIPTION
This change enhances the error handling in the `FilterEngine::processFrame()` pipeline by refactoring core interfaces to use `ResultPayload`. It ensures that any failure in the filter processing or the pipeline graph execution (including upstream node failures) is explicitly bubbled up to the caller with a descriptive error code and message, preventing silent degradation or "pseudosuccess" where an input texture might have been returned on failure.

Fixes #72

---
*PR created automatically by Jules for task [14821519506251620794](https://jules.google.com/task/14821519506251620794) started by @zx2121651*