### PR TITLE
Stabilize PipelineGraph::execute() invalid-state handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ add_library(video_sdk_core STATIC ${CORE_SOURCES})
 add_executable(test_filter_graph tests/test_filter_graph.cpp tests/mocks/MockCompositor.cpp)
 target_link_libraries(test_filter_graph video_sdk_core)
 
+add_executable(test_execute_stability_repro tests/test_execute_stability_repro.cpp tests/mocks/MockCompositor.cpp)
+if (NOT WIN32 AND NOT GLES2_LIBRARY)
+    target_include_directories(test_execute_stability_repro PRIVATE ${CMAKE_SOURCE_DIR}/mock_gl)
+endif()
+target_link_libraries(test_execute_stability_repro video_sdk_core)
+
 add_executable(test_lifecycle tests/test_lifecycle.cpp tests/mocks/MockCompositor.cpp)
 if (NOT WIN32 AND NOT GLES2_LIBRARY)
     target_include_directories(test_lifecycle PRIVATE ${CMAKE_SOURCE_DIR}/mock_gl)

--- a/core/include/pipeline/Nodes.h
+++ b/core/include/pipeline/Nodes.h
@@ -2,6 +2,7 @@
 
 #include "PipelineNode.h"
 #include "../Filter.h"
+#include "../FrameBufferPool.h"
 #include <mutex>
 
 namespace sdk {

--- a/core/include/pipeline/PipelineGraph.h
+++ b/core/include/pipeline/PipelineGraph.h
@@ -26,7 +26,7 @@ public:
     Result execute(int64_t timestampNs);
 
     const std::vector<NodePtr>& getNodes() const { return m_nodes; }
-    void detachAllNodes() { m_nodes.clear(); m_sortedNodes.clear(); m_sinkNodes.clear(); }
+    void detachAllNodes() { m_nodes.clear(); m_sortedNodes.clear(); m_sinkNodes.clear(); m_isCompiled = false; }
     void release();
 
 private:

--- a/core/src/Filter.cpp
+++ b/core/src/Filter.cpp
@@ -25,6 +25,7 @@ Filter::~Filter() {
 }
 
 Result Filter::initialize() {
+    release();
     m_programId = createProgram(getVertexShaderSource().c_str(), getFragmentShaderSource().c_str());
     if (m_programId == 0) {
         return Result::error(ErrorCode::ERR_INIT_SHADER_FAILED, "Failed to create program for " + getFragmentShaderName());

--- a/core/src/pipeline/PipelineGraph.cpp
+++ b/core/src/pipeline/PipelineGraph.cpp
@@ -49,10 +49,15 @@ void topoSortUtil(PipelineNode* node, std::unordered_set<PipelineNode*>& visited
     sorted.push_back(node);
 }
 Result PipelineGraph::compile() {
+    m_isCompiled = false;
     std::unordered_set<PipelineNode*> visited;
     std::unordered_set<PipelineNode*> recStack;
 
     m_sinkNodes.clear();
+
+    if (m_nodes.empty()) {
+        return Result::error(ErrorCode::ERR_GRAPH_NO_SINK, "Invalid Graph: No nodes added");
+    }
 
     for (auto& node : m_nodes) {
         if (detectCycleUtil(node.get(), visited, recStack)) {
@@ -92,6 +97,10 @@ Result PipelineGraph::compile() {
 Result PipelineGraph::execute(int64_t timestampNs) {
     if (!m_isCompiled) {
         return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "PipelineGraph executed before successful compile()");
+    }
+
+    if (m_sinkNodes.empty()) {
+        return Result::error(ErrorCode::ERR_GRAPH_NO_SINK, "PipelineGraph has no sink nodes and cannot be executed");
     }
 
     // In a pure pull model, we just ask the sinks to pull.

--- a/tests/test_execute_stability_repro.cpp
+++ b/tests/test_execute_stability_repro.cpp
@@ -1,0 +1,79 @@
+
+#include <iostream>
+#include <cassert>
+#include <memory>
+#include "../core/include/pipeline/PipelineGraph.h"
+#include "../core/include/pipeline/Nodes.h"
+
+using namespace sdk::video;
+
+class MockFailureFilter : public Filter {
+public:
+    Result initialize() override {
+        return Result::error(-1, "Forced Init Failure");
+    }
+protected:
+    void onDraw(const Texture&, FrameBufferPtr) override {}
+    std::string getFragmentShaderSource() const override { return ""; }
+    std::string getFragmentShaderName() const override { return "mock"; }
+};
+
+void test_detach_nodes_resets_compiled() {
+    PipelineGraph graph;
+    auto node = std::make_shared<CameraInputNode>("input");
+    graph.addNode(node);
+    graph.compile();
+
+    // Check if it's compiled (internal state check via execute result)
+    // Result res = graph.execute(0); // If it was NOT compiled, it would return ERR_RENDER_INVALID_STATE
+    // assert(res.getErrorCode() != ErrorCode::ERR_RENDER_INVALID_STATE);
+
+    graph.detachAllNodes();
+
+    // BUG: detachAllNodes() should reset m_isCompiled.
+    // If it doesn't, execute might try to run on cleared vectors.
+    Result res2 = graph.execute(0);
+    assert(res2.getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+}
+
+void test_empty_graph_compile() {
+    PipelineGraph graph;
+    Result res = graph.compile();
+    // Empty graph compile() should fail
+    assert(!res.isOk());
+    assert(res.getErrorCode() == ErrorCode::ERR_GRAPH_NO_SINK);
+}
+
+void test_compile_failure_resets_state() {
+    PipelineGraph graph;
+    auto nodeA = std::make_shared<CameraInputNode>("NodeA");
+    auto failFilter = std::make_shared<MockFailureFilter>();
+    auto nodeB = std::make_shared<FilterNode>("NodeB", failFilter);
+    auto nodeC = std::make_shared<OutputNode>("NodeC");
+
+    graph.addNode(nodeA);
+    graph.addNode(nodeB);
+    graph.addNode(nodeC);
+    graph.connect(nodeA, nodeB);
+    graph.connect(nodeB, nodeC);
+
+    // First, make it valid so it compiles
+    // (Wait, I can't easily swap the filter. I'll just try to compile it once and it should fail)
+
+    Result res = graph.compile();
+    assert(!res.isOk());
+
+    // BUG: If compile failed, m_isCompiled might still be whatever it was before (or false if it's new).
+    // But we want to ensure it's DEFINITELY false.
+
+    Result execRes = graph.execute(0);
+    assert(execRes.getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+}
+
+int main() {
+    std::cout << "Running stability repro tests..." << std::endl;
+    test_detach_nodes_resets_compiled();
+    test_empty_graph_compile();
+    test_compile_failure_resets_state();
+    return 0;
+}


### PR DESCRIPTION
This PR stabilizes the `PipelineGraph` execution by ensuring that it only runs when in a successfully compiled state. 

Key changes:
1.  **State Management**: `m_isCompiled` is now strictly managed. It is reset when nodes are detached and at the very beginning of the compilation process. This prevents the graph from being in a "stale" compiled state if a subsequent compilation fails.
2.  **Empty Graph Handling**: Compilation and execution of empty graphs are now explicitly handled as errors (`ERR_GRAPH_NO_SINK`), closing a previous loophole where empty graphs were considered valid.
3.  **Defensive Execution**: Added a check in `execute()` to ensure `m_sinkNodes` is not empty, providing a secondary guard against partially initialized or corrupted graph states.
4.  **Filter Robustness**: `Filter::initialize()` now explicitly calls `release()` before starting, preventing potential GL resource leaks if initialized multiple times.
5.  **Regression Testing**: Introduced `tests/test_execute_stability_repro.cpp` to verify these fixes and prevent future regressions.

Verified with `test_filter_graph` and the new `test_execute_stability_repro`.

Fixes #75

---
*PR created automatically by Jules for task [14194039004508738316](https://jules.google.com/task/14194039004508738316) started by @zx2121651*