### PR TITLE
Harden Android NativeBridge initialization failure handling

### DIFF
--- a/android/src/main/cpp/NativeBridge.cpp
+++ b/android/src/main/cpp/NativeBridge.cpp
@@ -44,6 +44,8 @@ struct EngineWrapper {
     ~EngineWrapper() {
 #ifndef WIN32
         releaseRecordingSurface();
+        glDeleteProgram(recordProgram);
+        recordProgram = 0;
 #endif
     }
 
@@ -184,10 +186,16 @@ Java_com_sdk_video_RenderEngine_nativeInit(JNIEnv *env, jobject thiz, jobject as
     if (!g_lastFrameTimeMsId) {
         jclass cls = env->GetObjectClass(thiz);
         g_lastFrameTimeMsId = env->GetFieldID(cls, "lastFrameTimeMs", "J");
+        env->DeleteLocalRef(cls);
     }
 
-    EngineWrapper* wrapper = new EngineWrapper();
-    wrapper->filterEngine = std::make_shared<FilterEngine>();
+    std::unique_ptr<EngineWrapper> wrapper;
+    try {
+        wrapper = std::make_unique<EngineWrapper>();
+    } catch (const std::bad_alloc& e) {
+        throwNativeException(env, static_cast<int>(ErrorCode::ERR_INIT_CONTEXT_FAILED), "Native Memory Allocation Failed");
+        return 0;
+    }
 
     if (assetManager) {
         AAssetManager* nativeAssetManager = AAssetManager_fromJava(env, assetManager);
@@ -196,14 +204,18 @@ Java_com_sdk_video_RenderEngine_nativeInit(JNIEnv *env, jobject thiz, jobject as
     }
 
     auto oesFilter = std::make_shared<OES2RGBFilter>();
-    wrapper->filterEngine->addFilterRaw(oesFilter);
+    auto addRes = wrapper->filterEngine->addFilterRaw(oesFilter);
+    if (!addRes.isOk()) {
+        throwNativeException(env, addRes.getErrorCode(), "Failed to add initial OES filter: " + addRes.getMessage());
+        return 0;
+    }
+
     auto res = wrapper->filterEngine->initialize();
     if (!res.isOk()) {
-        delete wrapper;
         throwNativeException(env, res.getErrorCode(), res.getMessage());
         return 0;
     }
-    return reinterpret_cast<jlong>(wrapper);
+    return reinterpret_cast<jlong>(wrapper.release());
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
This PR hardens the Android NativeBridge initialization path to prevent invalid states and resource leaks. Key changes include using `std::unique_ptr` for the `EngineWrapper` during initialization to ensure cleanup on failure, fixing a JNI local reference leak, and properly propagating initialization errors from the C++ core to the Kotlin layer. verified with `test_lifecycle` binary and Android unit tests.

Fixes #77

---
*PR created automatically by Jules for task [5683800434692165837](https://jules.google.com/task/5683800434692165837) started by @zx2121651*