### PR TITLE
[Android] Stabilize GL-thread dispatch and ensure real execution results

### DIFF
--- a/android/src/main/cpp/NativeBridge.cpp
+++ b/android/src/main/cpp/NativeBridge.cpp
@@ -50,14 +50,14 @@ struct EngineWrapper {
     }
 
 #ifndef WIN32
-    void setupRecordingSurface(JNIEnv* env, jobject surface) {
-        if (!surface) return;
+    bool setupRecordingSurface(JNIEnv* env, jobject surface) {
+        if (!surface) return false;
 
         // Cleanup existing surface before overwriting
         releaseRecordingSurface();
 
         recordingWindow = ANativeWindow_fromSurface(env, surface);
-        if (!recordingWindow) return;
+        if (!recordingWindow) return false;
 
         // Current context from GLSurfaceView or TextureView
         eglDisplay = eglGetCurrentDisplay();
@@ -66,7 +66,7 @@ struct EngineWrapper {
         if (eglDisplay == EGL_NO_DISPLAY || sharedContext == EGL_NO_CONTEXT) {
             ANativeWindow_release(recordingWindow);
             recordingWindow = nullptr;
-            return;
+            return false;
         }
 
         // Create EGL window surface for MediaCodec input
@@ -106,6 +106,7 @@ struct EngineWrapper {
             glAttachShader(recordProgram, vs); glAttachShader(recordProgram, fs);
             glLinkProgram(recordProgram);
         }
+        return true;
     }
 
     void releaseRecordingSurface() {
@@ -315,7 +316,9 @@ Java_com_sdk_video_RenderEngine_nativeSetRecordingSurface(JNIEnv *env, jobject t
     }
 
     if (surface) {
-        wrapper->setupRecordingSurface(env, surface);
+        if (!wrapper->setupRecordingSurface(env, surface)) {
+            throwNativeException(env, static_cast<int>(sdk::video::ERR_INIT_CONTEXT_FAILED), "Failed to setup recording surface (EGL Context missing?)");
+        }
     } else {
         wrapper->releaseRecordingSurface();
     }
@@ -451,10 +454,14 @@ Java_com_sdk_video_RenderEngine_nativeUpdateShaderSource(JNIEnv *env, jobject th
     const char* nameStr = env->GetStringUTFChars(name, nullptr);
     const char* sourceStr = env->GetStringUTFChars(source, nullptr);
 
-    wrapper->filterEngine->updateShaderSource(nameStr, sourceStr);
+    auto res = wrapper->filterEngine->updateShaderSource(nameStr, sourceStr);
 
     env->ReleaseStringUTFChars(name, nameStr);
     env->ReleaseStringUTFChars(source, sourceStr);
+
+    if (!res.isOk()) {
+        throwNativeException(env, res.getErrorCode(), res.getMessage());
+    }
 }
 
 JNIEXPORT jfloatArray JNICALL

--- a/android/src/main/java/com/sdk/video/FilterCameraPreview.kt
+++ b/android/src/main/java/com/sdk/video/FilterCameraPreview.kt
@@ -73,7 +73,12 @@ fun FilterCameraPreview(
                                 // ---- 【核心修复：GL 线程归属权】 ----
                                 // 在 GLSurfaceView 分配的 GLThread 中初始化底层渲染引擎
                                 // 这保证了底层 FBO、Texture 和 GLSurfaceView 永远在同一个上下文中
-                                filterManager.initialize()
+                                scope.launch {
+                                    val res = filterManager.initialize()
+                                    if (res.isFailure) {
+                                        android.util.Log.e("FilterCameraPreview", "Failed to initialize: ${res.exceptionOrNull()?.message}")
+                                    }
+                                }
 //                                 kotlinx.coroutines.GlobalScope.launch { filterManager.addFilter(VideoFilterType.COMPUTE_BLUR) }
 
                                 val vertexShader = loadShader(GLES20.GL_VERTEX_SHADER, vertexShaderCode)

--- a/android/src/main/java/com/sdk/video/VideoFilterManager.kt
+++ b/android/src/main/java/com/sdk/video/VideoFilterManager.kt
@@ -23,7 +23,7 @@ enum class FilterEngineState {
  * 1. 使用 Kotlin 协程和专属的单线程调度器 (GLRenderThread) 来保障 OpenGL 上下文的线程安全。
  * 2. 使用 SharedFlow (共享数据流) 作为生产者-消费者模型，向外界抛出处理后的纹理 ID，解耦底层渲染与上层 UI。
  */
-@OptIn(InternalApi::class)
+@OptIn(InternalApi::class, ExperimentalCoroutinesApi::class)
 class VideoFilterManager(private val context: android.content.Context,
     private val width: Int,
     private val height: Int,

--- a/android/src/main/java/com/sdk/video/VideoFilterManager.kt
+++ b/android/src/main/java/com/sdk/video/VideoFilterManager.kt
@@ -47,8 +47,17 @@ class VideoFilterManager(private val context: android.content.Context,
     // 这解决了之前 "依靠约定保证单线程" 带来的巨大维护隐患。
     var glThreadDispatcher: ((Runnable) -> Unit)? = null
 
+    @Volatile
+    private var glThreadId: Long = -1
+
     // 将所有的配置更新请求统一收敛并安全分发给 GL 线程，并挂起等待执行结果
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun <T> runOnGLThread(action: () -> Result<T>): Result<T> {
+        // [Optimization]: If already on GL thread, execute immediately to reduce latency
+        if (glThreadId != -1L && Thread.currentThread().id == glThreadId) {
+            return try { action() } catch (e: Exception) { Result.failure(e) }
+        }
+
         val dispatcher = glThreadDispatcher
             ?: return Result.failure(IllegalStateException("GL thread dispatcher not bound. Cannot execute GL action."))
 
@@ -57,11 +66,11 @@ class VideoFilterManager(private val context: android.content.Context,
                 try {
                     val result = action()
                     if (continuation.isActive) {
-                        continuation.resume(result, null)
+                        continuation.resume(result) { /* cancellation cleanup */ }
                     }
                 } catch (e: Exception) {
                     if (continuation.isActive) {
-                        continuation.resume(Result.failure(e), null)
+                        continuation.resume(Result.failure(e)) { }
                     }
                 }
             }
@@ -89,11 +98,15 @@ class VideoFilterManager(private val context: android.content.Context,
     val performanceMetrics: StateFlow<RenderEngine.PerformanceMetrics?> = _performanceMetrics.asStateFlow()
 
     // 初始化引擎，必须切换到专属的 GL 线程
-    fun initialize(): Result<Unit> {
-        try {
+    suspend fun initialize(): Result<Unit> {
+        return runOnGLThread {
             _engineState.value = FilterEngineState.INITIALIZING
+
+            // Capture GL thread ID for optimization
+            glThreadId = Thread.currentThread().id
+
             val res = renderEngine.init(context.assets)
-            if (res != 0) return Result.failure(VideoSdkError.fromNativeCode(res))
+            if (res != 0) return@runOnGLThread Result.failure(VideoSdkError.fromNativeCode(res))
 
             // 监听底层渲染错误
             renderEngine.onRenderErrorListener = { errorCode, errorMessage ->
@@ -102,7 +115,7 @@ class VideoFilterManager(private val context: android.content.Context,
             }
 
             // 监听性能数据
-            renderEngine.onPerformanceUpdateListener = { durationMs ->
+            renderEngine.onPerformanceUpdateListener = { _ ->
                 // 每次性能回调时主动拉取一次 metrics 并推到流里
                 _performanceMetrics.value = renderEngine.getMetrics()
             }
@@ -124,14 +137,13 @@ class VideoFilterManager(private val context: android.content.Context,
             if (st != null) {
                 inputSurface = Surface(st)
                 _engineState.value = FilterEngineState.RUNNING
-                return Result.success(Unit)
+                Result.success(Unit)
             } else {
-                return Result.failure(Exception("Failed to create input surface"))
+                Result.failure(Exception("Failed to create input surface"))
             }
-        } catch (e: Exception) {
+        }.onFailure { e ->
             _engineState.value = FilterEngineState.ERROR
             _processedFrames.tryEmit(Result.failure(e))
-            return Result.failure(e)
         }
     }
 
@@ -179,26 +191,29 @@ class VideoFilterManager(private val context: android.content.Context,
 
     // --- 音视频录制代理方法 ---
 
-    fun startVideoRecording(config: VideoExportConfig): Result<Unit> {
-        return try {
-            val encoder = VideoEncoder(this, config)
-            val surface = encoder.startRecording()
-            if (surface != null) {
-                videoEncoder = encoder
-                renderEngine.setRecordingAnchor(encoder.getStartTimeNs())
-                renderEngine.startRecording(surface)
-            } else {
-                Result.failure(VideoSdkError.InvalidOperation("Failed to start MediaCodec encoder"))
-            }
-        } catch (e: Exception) {
-            Result.failure(VideoSdkError.InvalidOperation(e.message ?: "Encoder exception"))
+    suspend fun startVideoRecording(config: VideoExportConfig): Result<Unit> {
+        val encoder = VideoEncoder(this, config)
+        val surface = encoder.startRecording()
+            ?: return Result.failure(VideoSdkError.InvalidOperation("Failed to start MediaCodec encoder"))
+
+        val glResult = runOnGLThread {
+            videoEncoder = encoder
+            renderEngine.setRecordingAnchor(encoder.getStartTimeNs())
+            renderEngine.startRecording(surface)
         }
+
+        if (glResult.isFailure) {
+            encoder.stopRecording()
+            videoEncoder = null
+        }
+        return glResult
     }
 
-    fun stopVideoRecording(isFallback: Boolean = false) {
-        renderEngine.stopRecording()
+    suspend fun stopVideoRecording(isFallback: Boolean = false): Result<Unit> {
+        val res = runOnGLThread { renderEngine.stopRecording() }
         videoEncoder?.stopRecording(isFallback)
         videoEncoder = null
+        return res
     }
 
     // Oboe 音频控制不需要强制在 GL 线程，但为了统一管理也可以放进来
@@ -236,7 +251,8 @@ class VideoFilterManager(private val context: android.content.Context,
     }
     fun release() {
         // 1. 先停掉录制和音频，防止异步任务还在调用 renderEngine
-        stopVideoRecording()
+        videoEncoder?.stopRecording()
+        videoEncoder = null
         stopAudioRecord()
 
         inputSurface?.release()
@@ -249,6 +265,7 @@ class VideoFilterManager(private val context: android.content.Context,
             // 将释放命令丢至 GL 线程队列的绝对末尾
             dispatcher.invoke {
                 try {
+                    renderEngine.stopRecording()
                     renderEngine.release()
                     Log.i("VideoFilterManager", "RenderEngine safely deleted via Poison Pill.")
                 } catch (e: Exception) {

--- a/core/include/Filter.h
+++ b/core/include/Filter.h
@@ -23,7 +23,7 @@ public:
 
     virtual Result initialize();
     virtual void onProgramRecompiled() {}
-    virtual void recompileProgram();
+    virtual Result recompileProgram();
     void setShaderManager(std::shared_ptr<ShaderManager> manager) { m_shaderManager = manager; }
     virtual void release();
 

--- a/core/include/FilterEngine.h
+++ b/core/include/FilterEngine.h
@@ -52,7 +52,7 @@ public:
 
     PerformanceMetrics getPerformanceMetrics() const { return m_metricsCollector.getMetrics(); }
     void recordDroppedFrame() { m_metricsCollector.recordDroppedFrame(); }
-    void updateShaderSource(const std::string& name, const std::string& source);
+    Result updateShaderSource(const std::string& name, const std::string& source);
 
 
     // 暴露 FBO 内存池供子滤镜（如 Two-pass 高斯模糊）借用

--- a/core/src/Filter.cpp
+++ b/core/src/Filter.cpp
@@ -135,7 +135,7 @@ GLuint Filter::createProgram(const char* pVertexSource, const char* pFragmentSou
 
 
 
-void Filter::recompileProgram() {
+Result Filter::recompileProgram() {
     std::string vertexShaderSource = getVertexShaderSource();
     std::string fragmentShaderSource = getFragmentShaderSource();
 
@@ -146,20 +146,23 @@ void Filter::recompileProgram() {
 
     // Create new program
     GLuint newProgramId = createProgram(vertexShaderSource.c_str(), fragmentShaderSource.c_str());
-    if (newProgramId != 0) {
-        // Delete old
-        if (m_programId != 0) {
-            glDeleteProgram(m_programId);
-        }
-        m_programId = newProgramId;
-
-        // Update locations
-        m_positionHandle = glGetAttribLocation(m_programId, "position");
-        m_texCoordHandle = glGetAttribLocation(m_programId, "inputTextureCoordinate");
-        m_inputImageTextureHandle = glGetUniformLocation(m_programId, "inputImageTexture");
-
-        onProgramRecompiled();
+    if (newProgramId == 0) {
+        return Result::error(ErrorCode::ERR_INIT_SHADER_FAILED, "Failed to recompile program for " + getFragmentShaderName());
     }
+
+    // Delete old
+    if (m_programId != 0) {
+        glDeleteProgram(m_programId);
+    }
+    m_programId = newProgramId;
+
+    // Update locations
+    m_positionHandle = glGetAttribLocation(m_programId, "position");
+    m_texCoordHandle = glGetAttribLocation(m_programId, "inputTextureCoordinate");
+    m_inputImageTextureHandle = glGetUniformLocation(m_programId, "inputImageTexture");
+
+    onProgramRecompiled();
+    return Result::ok();
 }
 
 } // namespace video

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -131,25 +131,20 @@ Result FilterEngine::addFilterRaw(FilterPtr filter) {
         auto filterNode = std::make_shared<FilterNode>("Filter_" + std::to_string(m_graph->getNodes().size()), filter);
         m_graph->addNode(filterNode);
         if (m_initialized) {
-            filter->initialize();
+            auto res = filter->initialize();
+            if (!res.isOk()) return res;
         }
         m_isGraphDirty = true;
+        return Result::ok();
     }
-    return Result::ok();
+    return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Filter is null");
 }
 Result FilterEngine::addFilter(FilterType type) {
     FilterPtr filter = FilterFactory::createFilter(type, m_contextManager, &m_frameBufferPool);
     if (filter) {
-        filter->setShaderManager(m_shaderManager);
-        if (!m_graph) { m_graph = std::make_shared<PipelineGraph>(); }
-        auto filterNode = std::make_shared<FilterNode>("Filter_" + std::to_string(m_graph->getNodes().size()), filter);
-        m_graph->addNode(filterNode);
-        if (m_initialized) {
-            filter->initialize();
-        }
-        m_isGraphDirty = true;
+        return addFilterRaw(filter);
     }
-    return Result::ok();
+    return Result::error(ErrorCode::ERR_INIT_SHADER_FAILED, "Failed to create filter from factory");
 }
 
 Result FilterEngine::removeAllFilters() {
@@ -163,8 +158,8 @@ Result FilterEngine::removeAllFilters() {
 
 
 
-void FilterEngine::updateShaderSource(const std::string& name, const std::string& source) {
-    if (!m_shaderManager) return;
+Result FilterEngine::updateShaderSource(const std::string& name, const std::string& source) {
+    if (!m_shaderManager) return Result::error("ShaderManager is null");
 
     m_shaderManager->updateShaderSource(name, source);
 
@@ -175,10 +170,12 @@ void FilterEngine::updateShaderSource(const std::string& name, const std::string
         for (const auto& node : m_graph->getNodes()) {
             auto filterNode = std::dynamic_pointer_cast<FilterNode>(node);
             if (filterNode && filterNode->getFilter()) {
-                filterNode->getFilter()->recompileProgram();
+                auto res = filterNode->getFilter()->recompileProgram();
+                if (!res.isOk()) return res;
             }
         }
     }
+    return Result::ok();
 }
 
 Result FilterEngine::buildCameraPipeline() {

--- a/sample-android/src/main/java/com/sdk/video/sample/MainActivity.kt
+++ b/sample-android/src/main/java/com/sdk/video/sample/MainActivity.kt
@@ -198,12 +198,16 @@ class MainActivity : ComponentActivity() {
             outputPath = outputFile.absolutePath
         )
 
-        val result = fm.startVideoRecording(config)
-        if (result.isSuccess) {
-            isRecordingState.value = true
-            Toast.makeText(this, "Recording started", Toast.LENGTH_SHORT).show()
-        } else {
-            Toast.makeText(this, "Failed to start recording: ${result.exceptionOrNull()?.message}", Toast.LENGTH_LONG).show()
+        fm.scope.launch {
+            val result = fm.startVideoRecording(config)
+            runOnUiThread {
+                if (result.isSuccess) {
+                    isRecordingState.value = true
+                    Toast.makeText(this@MainActivity, "Recording started", Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(this@MainActivity, "Failed to start recording: ${result.exceptionOrNull()?.message}", Toast.LENGTH_LONG).show()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR stabilizes the GL-thread dispatch logic in VideoFilterManager by enforcing synchronous-style waiting on the GL thread using coroutines and ensuring that all GL operations return real execution results from the native C++ layer. Key improvements include optimized thread-affinity checks, enhanced error propagation through the JNI bridge, and hardening of the recording lifecycle.

Fixes #80

---
*PR created automatically by Jules for task [17827730816607449363](https://jules.google.com/task/17827730816607449363) started by @zx2121651*