### PR TITLE
Unify Android engine state and error propagation

### DIFF
--- a/android/src/main/java/com/sdk/video/FilterCameraPreview.kt
+++ b/android/src/main/java/com/sdk/video/FilterCameraPreview.kt
@@ -38,7 +38,7 @@ fun FilterCameraPreview(
 
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         if (engineState == FilterEngineState.ERROR) {
-            Text("Camera failed. Degrading to safe mode...", color = Color.Red)
+            Text("Critical Engine Error. Please restart the app.", color = Color.Red)
         } else {
             AndroidView(
                 modifier = Modifier.fillMaxSize(),
@@ -125,7 +125,8 @@ fun FilterCameraPreview(
 
                                 GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
 
-                                if (currentTextureId >= 0 && engineState != FilterEngineState.DEGRADED) {
+                                if (currentTextureId >= 0) {
+                                    // Even if DEGRADED, we still want to show the frame (it might be the last successful one or a fallback)
                                     GLES20.glUseProgram(displayProgram)
 
 
@@ -169,6 +170,13 @@ fun FilterCameraPreview(
                     }
                 }
             )
+        }
+
+        // Error/Warning Overlay
+        if (engineState == FilterEngineState.DEGRADED) {
+            Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.TopCenter) {
+                Text("Warning: Engine degraded. Some filters may be disabled.", color = Color.Yellow)
+            }
         }
 
         // Overlay UI

--- a/android/src/main/java/com/sdk/video/RenderEngine.kt
+++ b/android/src/main/java/com/sdk/video/RenderEngine.kt
@@ -145,13 +145,18 @@ class RenderEngine(private val width: Int, private val height: Int) : SurfaceTex
 
             val outputTexId = nativeProcessFrame(nativeHandle, oesTextureId, width, height, transformMatrix, timestampNs)
 
-            // 如果返回值是负数，表示产生了错误 (onNativeRenderError is called from C++)
+            // 如果返回值是负数，表示产生了错误
             if (outputTexId >= 0) {
                 onFrameProcessedListener?.invoke(outputTexId)
                 if (lastFrameTimeMs > 0) {
                     onPerformanceUpdateListener?.invoke(lastFrameTimeMs)
                 }
+            } else {
+                // Defensive fallback: if native code returned an error but didn't call onNativeRenderError callback
+                // (e.g., due to JNI reference issues), we manually notify the listener.
+                onRenderErrorListener?.invoke(outputTexId, "Native frame processing failed with code: $outputTexId")
             }
+            Unit
         }
     }
 

--- a/android/src/main/java/com/sdk/video/VideoFilterManager.kt
+++ b/android/src/main/java/com/sdk/video/VideoFilterManager.kt
@@ -97,6 +97,30 @@ class VideoFilterManager(private val context: android.content.Context,
     private val _performanceMetrics = MutableStateFlow<RenderEngine.PerformanceMetrics?>(null)
     val performanceMetrics: StateFlow<RenderEngine.PerformanceMetrics?> = _performanceMetrics.asStateFlow()
 
+    /**
+     * Unified error handling for both synchronous initialization and asynchronous rendering errors.
+     * Categorizes errors into fatal (ERROR) or recoverable (DEGRADED).
+     */
+    private fun handleError(errorCode: Int, errorMessage: String) {
+        val isFatal = VideoSdkError.isFatal(errorCode)
+        val newState = if (isFatal) FilterEngineState.ERROR else FilterEngineState.DEGRADED
+
+        // Update engine state (but don't overwrite ERROR with DEGRADED)
+        if (_engineState.value != FilterEngineState.ERROR) {
+            _engineState.value = newState
+        }
+
+        // Propagate failure to the processed frames flow
+        val error = VideoSdkError.NativeError(errorCode, errorMessage)
+        _processedFrames.tryEmit(Result.failure(error))
+
+        if (isFatal) {
+            Log.e("VideoFilterManager", "FATAL ENGINE ERROR: $errorMessage")
+        } else {
+            Log.w("VideoFilterManager", "Engine degraded: $errorMessage")
+        }
+    }
+
     // 初始化引擎，必须切换到专属的 GL 线程
     suspend fun initialize(): Result<Unit> {
         return runOnGLThread {
@@ -106,12 +130,14 @@ class VideoFilterManager(private val context: android.content.Context,
             glThreadId = Thread.currentThread().id
 
             val res = renderEngine.init(context.assets)
-            if (res != 0) return@runOnGLThread Result.failure(VideoSdkError.fromNativeCode(res))
+            if (res != 0) {
+                handleError(res, "Initialization failed")
+                return@runOnGLThread Result.failure(VideoSdkError.fromNativeCode(res))
+            }
 
-            // 监听底层渲染错误
+            // 监听底层渲染错误 (Callback from JNI)
             renderEngine.onRenderErrorListener = { errorCode, errorMessage ->
-                _engineState.value = FilterEngineState.DEGRADED // or ERROR
-                _processedFrames.tryEmit(Result.failure(VideoSdkError.NativeError(errorCode, errorMessage)))
+                handleError(errorCode, errorMessage)
             }
 
             // 监听性能数据
@@ -122,13 +148,10 @@ class VideoFilterManager(private val context: android.content.Context,
 
             // 设置底层每处理完一帧的回调监听
             renderEngine.onFrameProcessedListener = { outputTexId ->
+                // Note: outputTexId < 0 cases are now handled by onRenderErrorListener
                 if (outputTexId >= 0) {
                     // 成功渲染，发送最新的纹理 ID 给 UI 层
                     _processedFrames.tryEmit(Result.success(outputTexId))
-                } else {
-                    // 异常降级：如果底层 C++ 渲染失败返回非法 ID，则抛出异常
-                    _processedFrames.tryEmit(Result.failure(RuntimeException("GL Engine Render Failed")))
-                    _engineState.value = FilterEngineState.DEGRADED // 状态变为降级
                 }
             }
 
@@ -139,11 +162,13 @@ class VideoFilterManager(private val context: android.content.Context,
                 _engineState.value = FilterEngineState.RUNNING
                 Result.success(Unit)
             } else {
-                Result.failure(Exception("Failed to create input surface"))
+                val e = Exception("Failed to create input surface")
+                handleError(-1001, e.message ?: "Unknown surface failure")
+                Result.failure(e)
             }
         }.onFailure { e ->
-            _engineState.value = FilterEngineState.ERROR
-            _processedFrames.tryEmit(Result.failure(e))
+            val code = if (e is VideoSdkError) e.code else -1
+            handleError(code, e.message ?: "Unknown async failure")
         }
     }
 

--- a/android/src/main/java/com/sdk/video/VideoSdkError.kt
+++ b/android/src/main/java/com/sdk/video/VideoSdkError.kt
@@ -26,6 +26,16 @@ sealed class VideoSdkError(message: String, val code: Int) : Exception("[$code] 
     class NativeError(code: Int, val nativeMessage: String) : VideoSdkError(nativeMessage, code)
 
     companion object {
+        /**
+         * Determines if an error is fatal (requires stopping the engine)
+         * or recoverable (allows falling back to a degraded mode).
+         */
+        fun isFatal(code: Int): Boolean {
+            // Initialization errors (-1000 to -1999) are considered fatal.
+            // Rendering and other runtime errors are often recoverable via bypass.
+            return code in -1999..-1000
+        }
+
         fun fromNativeCode(code: Int): VideoSdkError {
             return when (code) {
                 -1001 -> InitContextFailed()


### PR DESCRIPTION
Improved Android engine state and error propagation by unifying the reporting path. Centralized error handling in `VideoFilterManager` now correctly maps native error codes to `FilterEngineState.ERROR` or `DEGRADED` and propagates them via the `processedFrames` flow. UI components like `FilterCameraPreview` now provide appropriate feedback for both fatal and non-fatal errors.

Fixes #81

---
*PR created automatically by Jules for task [11435857098254740193](https://jules.google.com/task/11435857098254740193) started by @zx2121651*