### PR TITLE
[Android] Stabilize performance metrics exposure

### DIFF
--- a/android/src/main/java/com/sdk/video/VideoFilterManager.kt
+++ b/android/src/main/java/com/sdk/video/VideoFilterManager.kt
@@ -90,7 +90,7 @@ class VideoFilterManager(private val context: android.content.Context,
      */
     private val _processedFrames = MutableSharedFlow<Result<Int>>(
         extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
+        onBufferOverflow = BufferOverflow.SUSPEND
     )
     val processedFrames: SharedFlow<Result<Int>> = _processedFrames.asSharedFlow()
 
@@ -151,7 +151,11 @@ class VideoFilterManager(private val context: android.content.Context,
                 // Note: outputTexId < 0 cases are now handled by onRenderErrorListener
                 if (outputTexId >= 0) {
                     // 成功渲染，发送最新的纹理 ID 给 UI 层
-                    _processedFrames.tryEmit(Result.success(outputTexId))
+                    // 使用 SUSPEND + tryEmit 来探测并记录丢帧情况（防背压降级）
+                    val emitted = _processedFrames.tryEmit(Result.success(outputTexId))
+                    if (!emitted) {
+                        renderEngine.recordDroppedFrame()
+                    }
                 }
             }
 

--- a/core/include/PerformanceMetrics.h
+++ b/core/include/PerformanceMetrics.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <chrono>
 #include <algorithm>
+#include <cmath>
 
 namespace sdk {
 namespace video {
@@ -59,9 +60,14 @@ public:
         }
         metrics.averageFrameTimeMs = sum / sorted.size();
 
-        metrics.p50FrameTimeMs = sorted[static_cast<size_t>(sorted.size() * 0.50)];
-        metrics.p90FrameTimeMs = sorted[static_cast<size_t>(sorted.size() * 0.90)];
-        metrics.p99FrameTimeMs = sorted[static_cast<size_t>(sorted.size() * 0.99)];
+        auto getPercentile = [&](float p) {
+            size_t idx = static_cast<size_t>(std::floor(p * (sorted.size() - 1)));
+            return sorted[idx];
+        };
+
+        metrics.p50FrameTimeMs = getPercentile(0.50f);
+        metrics.p90FrameTimeMs = getPercentile(0.90f);
+        metrics.p99FrameTimeMs = getPercentile(0.99f);
 
         return metrics;
     }

--- a/sample-android/src/main/java/com/sdk/video/sample/MainActivity.kt
+++ b/sample-android/src/main/java/com/sdk/video/sample/MainActivity.kt
@@ -47,7 +47,10 @@ class MainActivity : ComponentActivity() {
 
     // Compose State
     private var isRecordingState = mutableStateOf(false)
-    private var performanceMs = mutableStateOf(0L)
+    private var avgFrameTime = mutableStateOf(0f)
+    private var p50FrameTime = mutableStateOf(0f)
+    private var p90FrameTime = mutableStateOf(0f)
+    private var p99FrameTime = mutableStateOf(0f)
     private var droppedFrames = mutableStateOf(0)
 
     companion object {
@@ -83,9 +86,12 @@ class MainActivity : ComponentActivity() {
                         .padding(16.dp)
                 ) {
                     Text(
-                        text = "Frame: ${performanceMs.value} ms",
-                        color = if (performanceMs.value > 16) Color.Red else Color.Green
+                        text = "Avg: ${String.format("%.1f", avgFrameTime.value)} ms",
+                        color = if (avgFrameTime.value > 16) Color.Red else Color.Green
                     )
+                    Text(text = "P50: ${String.format("%.1f", p50FrameTime.value)} ms", color = Color.White)
+                    Text(text = "P90: ${String.format("%.1f", p90FrameTime.value)} ms", color = Color.White)
+                    Text(text = "P99: ${String.format("%.1f", p99FrameTime.value)} ms", color = Color.White)
                     Text(
                         text = "Dropped: ${droppedFrames.value}",
                         color = if (droppedFrames.value > 0) Color.Red else Color.White
@@ -140,7 +146,10 @@ class MainActivity : ComponentActivity() {
                     newManager.performanceMetrics.collect { metrics ->
                         metrics?.let {
                             runOnUiThread {
-                                performanceMs.value = it.averageFrameTimeMs.toLong()
+                                avgFrameTime.value = it.averageFrameTimeMs
+                                p50FrameTime.value = it.p50FrameTimeMs
+                                p90FrameTime.value = it.p90FrameTimeMs
+                                p99FrameTime.value = it.p99FrameTimeMs
                                 droppedFrames.value = it.droppedFrames
                             }
                         }


### PR DESCRIPTION
This change stabilizes the performance metrics collection and exposure for the Android SDK.
- The C++ core `MetricsCollector` now uses a more robust percentile calculation.
- The Android `VideoFilterManager` now correctly identifies and records dropped frames when the UI processing cannot keep up with the rendering pipeline (backpressure).
- The sample application's UI has been updated to show Average, P50, P90, P99 frame times, and the total count of dropped frames.

Fixes #82

---
*PR created automatically by Jules for task [14572635990489831403](https://jules.google.com/task/14572635990489831403) started by @zx2121651*