### PR TITLE
[Android] Stabilize recording timestamp behavior in RenderEngine

### DIFF
--- a/android/src/main/java/com/sdk/video/RenderEngine.kt
+++ b/android/src/main/java/com/sdk/video/RenderEngine.kt
@@ -32,7 +32,8 @@ class RenderEngine(private val width: Int, private val height: Int) : SurfaceTex
     var lastFrameTimeMs: Long = 0L
 
     private var recordingStartTimeNs: Long = 0L
-    private var lastVideoPtsNs: Long = 0L
+    private var lastVideoPtsNs: Long = -1L
+    private var firstFrameSessionTimestamp: Long = -1L
     private var isRecording: Boolean = false
 
     var onFrameProcessedListener: ((outputTextureId: Int) -> Unit)? = null
@@ -129,18 +130,20 @@ class RenderEngine(private val width: Int, private val height: Int) : SurfaceTex
             st.getTransformMatrix(transformMatrix)
 
             // Pass timestamp to native layer for MediaCodec EGL presentation time
-            // [PTS Drift Fix]: Use audio master clock to forcefully align video PTS to the
-            // audio crystal if recording is active.
+            // [PTS Anchor Fix]: Use the first frame's SurfaceTexture timestamp as a relative baseline
+            // and offset it by the recording anchor. This maintains the camera's native cadence
+            // while ensuring the track starts exactly at the synchronized anchor.
             var timestampNs = st.timestamp
             if (isRecording && recordingStartTimeNs > 0) {
-                val audioTimeNs = getAudioTimeNs()
-                if (audioTimeNs > 0) {
-                    timestampNs = recordingStartTimeNs + audioTimeNs
-                    if (timestampNs <= lastVideoPtsNs) {
-                        timestampNs = lastVideoPtsNs + 10000 // Ensure strict monotonicity (10us)
-                    }
-                    lastVideoPtsNs = timestampNs
+                if (firstFrameSessionTimestamp == -1L) {
+                    firstFrameSessionTimestamp = timestampNs
                 }
+                timestampNs = recordingStartTimeNs + (timestampNs - firstFrameSessionTimestamp)
+
+                if (lastVideoPtsNs != -1L && timestampNs <= lastVideoPtsNs) {
+                    timestampNs = lastVideoPtsNs + 10000 // Ensure strict monotonicity (10us)
+                }
+                lastVideoPtsNs = timestampNs
             }
 
             val outputTexId = nativeProcessFrame(nativeHandle, oesTextureId, width, height, transformMatrix, timestampNs)
@@ -163,7 +166,8 @@ class RenderEngine(private val width: Int, private val height: Int) : SurfaceTex
     // Recording API
     fun setRecordingAnchor(anchorTimeNs: Long) {
         recordingStartTimeNs = anchorTimeNs
-        lastVideoPtsNs = anchorTimeNs
+        lastVideoPtsNs = -1L
+        firstFrameSessionTimestamp = -1L
     }
 
     fun startRecording(surface: Surface): Result<Unit> {

--- a/android/src/main/java/com/sdk/video/VideoEncoder.kt
+++ b/android/src/main/java/com/sdk/video/VideoEncoder.kt
@@ -54,6 +54,7 @@ class VideoEncoder(
     // 早鸟帧缓存队列：在 Muxer 启动前，缓存那些提前到来的 SPS/PPS 配置头或视频帧，防止丢帧
     private val pendingFrames = ConcurrentLinkedQueue<FrameData>()
     private var startTimeNs: Long = 0
+    private var totalSamplesEncoded: Long = 0
 
     fun getStartTimeNs(): Long = startTimeNs
 
@@ -77,6 +78,7 @@ class VideoEncoder(
 
             // Align the anchor time to what SurfaceTexture uses (System.nanoTime() typically matches CLOCK_MONOTONIC on Android)
             startTimeNs = System.nanoTime()
+            totalSamplesEncoded = 0
             isRecording = true
 
             videoCodec?.start()
@@ -200,21 +202,14 @@ class VideoEncoder(
                         inputBuffer?.clear()
                         inputBuffer?.put(buffer, 0, readBytes)
 
-                        // [PTS Drift Fix]: Base everything on an absolute system uptime anchor
-                        // to perfectly match the EGL presentation time `st.timestamp`.
-                        // Add the Oboe engine's true processed duration to this anchor.
-                        val audioDurationNs = filterManager.getAudioTimeNs()
-                        var pts: Long = 0
-                        if (audioDurationNs > 0) {
-                            pts = (startTimeNs + audioDurationNs) / 1000
-                        } else {
-                            pts = (System.nanoTime()) / 1000
-                        }
+                        // [PTS Drift Fix]: Use the total number of samples encoded as a stable clock.
+                        // This prevents drift between audio and video by tying PTS to the actual data volume,
+                        // starting from the synchronized system-time anchor.
+                        val samplesRead = readBytes / 2 // 16-bit Mono = 2 bytes per sample
+                        val pts = (startTimeNs + (totalSamplesEncoded * 1000000000L / audioSampleRate)) / 1000
+                        totalSamplesEncoded += samplesRead
 
                         synchronized(syncLock) {
-                            if (pts <= lastAudioPtsUs) {
-                                pts = lastAudioPtsUs + 10 // enforce monotonic strictness
-                            }
                             lastAudioPtsUs = pts
                         }
 


### PR DESCRIPTION
Stabilize Android recording timestamp behavior and AV sync by using relative offsets and sample-count based clocks.

Fixes #83

---
*PR created automatically by Jules for task [7813782117893390258](https://jules.google.com/task/7813782117893390258) started by @zx2121651*