### PR TITLE
Stabilize active clip selection in Track

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,12 @@ if (NOT WIN32 AND NOT GLES2_LIBRARY)
 endif()
 target_link_libraries(test_timeline video_sdk_core)
 
+add_executable(test_track_behavior tests/test_track_behavior.cpp)
+if (NOT WIN32 AND NOT GLES2_LIBRARY)
+    target_include_directories(test_track_behavior PRIVATE ${CMAKE_SOURCE_DIR}/mock_gl)
+endif()
+target_link_libraries(test_track_behavior video_sdk_core)
+
 add_executable(test_rebuild_harden tests/test_rebuild_harden.cpp tests/mocks/MockCompositor.cpp)
 if (NOT WIN32 AND NOT GLES2_LIBRARY)
     target_include_directories(test_rebuild_harden PRIVATE ${CMAKE_SOURCE_DIR}/mock_gl)

--- a/core/src/timeline/Track.cpp
+++ b/core/src/timeline/Track.cpp
@@ -13,8 +13,9 @@ void Track::addClip(ClipPtr clip) {
         // 并根据需求进行“吸附”、“覆盖”或“整体后移”逻辑。这里做简化插入。
         m_clips.push_back(clip);
 
-        // 插入后按在主时间轴的起始点 TimelineIn 从小到大排序，方便后续二分查找 Seek
-        std::sort(m_clips.begin(), m_clips.end(), [](const ClipPtr& a, const ClipPtr& b) {
+        // 插入后按在主时间轴的起始点 TimelineIn 从小到大排序，方便后续二分查找 Seek。
+        // 使用 stable_sort 以确保在 TimelineIn 相同时，维持插入顺序。
+        std::stable_sort(m_clips.begin(), m_clips.end(), [](const ClipPtr& a, const ClipPtr& b) {
             return a->getTimelineIn() < b->getTimelineIn();
         });
     }
@@ -36,9 +37,9 @@ void Track::clearClips() {
 ClipPtr Track::getActiveClipAtTime(int64_t timelineNs) const {
     if (m_clips.empty()) return nullptr;
 
-    // 因为 m_clips 是按 TimelineIn 有序的，可以用二分查找 (std::lower_bound) 优化，
-    // 这里为了演示 NLE 逻辑，直接线性遍历
-    for (const auto& clip : m_clips) {
+    // 从后往前遍历，这样在有重叠的情况下，会优先返回“最晚开始”或“最后插入”的片段（即位于上层的片段）。
+    for (auto it = m_clips.rbegin(); it != m_clips.rend(); ++it) {
+        const auto& clip = *it;
         int64_t start = clip->getTimelineIn();
         int64_t end = clip->getTimelineOut();
 
@@ -47,8 +48,9 @@ ClipPtr Track::getActiveClipAtTime(int64_t timelineNs) const {
             return clip;
         }
 
-        // 如果游标早于当前 Clip，说明后面的都无需找了（因为序列是有序的）
-        if (timelineNs < start) break;
+        // 如果 timelineNs 已经大于等于当前 clip 的结束时间，且由于 m_clips 是按 start 排序的，
+        // 我们不能简单的 break，因为前面的 clip 可能还在持续。
+        // 但由于我们是从后往前找，找到的第一个符合条件的 [start, end) 就是我们要的“最顶层”片段。
     }
 
     // 轨道在这个时间点是空的 (比如两段素材之间的黑屏过渡)

--- a/tests/test_track_behavior.cpp
+++ b/tests/test_track_behavior.cpp
@@ -1,0 +1,92 @@
+#include <iostream>
+#include <cassert>
+#include <memory>
+#include <vector>
+#include <string>
+#include "../core/include/timeline/Track.h"
+#include "../core/include/timeline/Clip.h"
+
+using namespace sdk::video::timeline;
+
+void test_track_stable_sort_same_timeline_in() {
+    Track track(0, Track::TrackType::MAIN_VIDEO);
+
+    // Add three clips at the same starting time
+    auto clip1 = std::make_shared<Clip>("clip_1", "v1.mp4", Clip::MediaType::VIDEO);
+    clip1->setTimelineIn(0);
+    clip1->setSourceDuration(1000000000);
+    clip1->setTrimOut(1000000000);
+
+    auto clip2 = std::make_shared<Clip>("clip_2", "v2.mp4", Clip::MediaType::VIDEO);
+    clip2->setTimelineIn(0);
+    clip2->setSourceDuration(1000000000);
+    clip2->setTrimOut(1000000000);
+
+    auto clip3 = std::make_shared<Clip>("clip_3", "v3.mp4", Clip::MediaType::VIDEO);
+    clip3->setTimelineIn(0);
+    clip3->setSourceDuration(1000000000);
+    clip3->setTrimOut(1000000000);
+
+    track.addClip(clip1);
+    track.addClip(clip2);
+    track.addClip(clip3);
+
+    // If we have multiple clips at the same time, we expect getActiveClipAtTime
+    // to return the "last added" one if we want "top-most" behavior on a single track
+    // Or at least it should be predictable.
+    // Currently, it returns the first one it finds.
+
+    auto active = track.getActiveClipAtTime(500000000); // 0.5s
+    assert(active != nullptr);
+    std::cout << "Active clip at 0.5s: " << active->getId() << std::endl;
+
+    // After fixing, we expect clip_3 (last added) to be returned if they overlap exactly.
+    // This is because in Compositor, we usually want the latest added clip to take precedence
+    // if they are on the same track (though ideally tracks shouldn't have overlaps except for transitions).
+    assert(active->getId() == "clip_3");
+
+    std::cout << "test_track_stable_sort_same_timeline_in passed" << std::endl;
+}
+
+void test_track_overlapping_selection() {
+    Track track(0, Track::TrackType::MAIN_VIDEO);
+
+    // Clip A: 0s - 2s
+    auto clipA = std::make_shared<Clip>("clip_A", "a.mp4", Clip::MediaType::VIDEO);
+    clipA->setTimelineIn(0);
+    clipA->setSourceDuration(2000000000);
+    clipA->setTrimOut(2000000000);
+    track.addClip(clipA);
+
+    // Clip B: 1s - 3s
+    auto clipB = std::make_shared<Clip>("clip_B", "b.mp4", Clip::MediaType::VIDEO);
+    clipB->setTimelineIn(1000000000);
+    clipB->setSourceDuration(2000000000);
+    clipB->setTrimOut(2000000000);
+    track.addClip(clipB);
+
+    // At 1.5s, both are active.
+    // getActiveClipAtTime should return Clip B because it started later (often used for transition "to" clip)
+    // or simply because it was added later/starts later.
+    auto active = track.getActiveClipAtTime(1500000000);
+    assert(active != nullptr);
+    assert(active->getId() == "clip_B");
+
+    std::cout << "test_track_overlapping_selection passed" << std::endl;
+}
+
+int main() {
+    try {
+        test_track_stable_sort_same_timeline_in();
+    } catch (const std::exception& e) {
+        std::cerr << "test_track_stable_sort_same_timeline_in failed: " << e.what() << std::endl;
+    }
+
+    try {
+        test_track_overlapping_selection();
+    } catch (const std::exception& e) {
+        std::cerr << "test_track_overlapping_selection failed: " << e.what() << std::endl;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This change improves the predictability of clip selection within a single Track in the timeline system. By using `std::stable_sort`, we ensure that clips added at the same `TimelineIn` maintain their relative order. By searching backwards in `getActiveClipAtTime`, we implement a "last-in-wins" policy for overlapping clips on the same track, which is a common convention in NLE systems. Added a new test file to verify these behaviors.

Fixes #87

---
*PR created automatically by Jules for task [16854140204913885096](https://jules.google.com/task/16854140204913885096) started by @zx2121651*