### PR TITLE
Reduce silent dummy fallback in DecoderPool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,12 @@ if (NOT WIN32 AND NOT GLES2_LIBRARY)
 endif()
 target_link_libraries(test_timeline video_sdk_core)
 
+add_executable(test_decoder_pool tests/test_decoder_pool.cpp)
+if (NOT WIN32 AND NOT GLES2_LIBRARY)
+    target_include_directories(test_decoder_pool PRIVATE ${CMAKE_SOURCE_DIR}/mock_gl)
+endif()
+target_link_libraries(test_decoder_pool video_sdk_core)
+
 add_executable(test_track_behavior tests/test_track_behavior.cpp)
 if (NOT WIN32 AND NOT GLES2_LIBRARY)
     target_include_directories(test_track_behavior PRIVATE ${CMAKE_SOURCE_DIR}/mock_gl)

--- a/core/include/timeline/Compositor.h
+++ b/core/include/timeline/Compositor.h
@@ -15,7 +15,7 @@ namespace timeline {
 class IDecoderPool {
 public:
     virtual ~IDecoderPool() = default;
-    virtual Texture getFrame(const std::string& clipId, int64_t localTimeNs) = 0;
+    virtual ResultPayload<Texture> getFrame(const std::string& clipId, int64_t localTimeNs) = 0;
 };
 
 class Compositor {

--- a/core/include/timeline/DecoderPool.h
+++ b/core/include/timeline/DecoderPool.h
@@ -23,10 +23,10 @@ public:
 
     // 核心接口：获取在 localTimeNs 微秒时刻，clipId 对应的视频解码后的 GL 纹理
     // requiresExactSeek: 如果为 true，表示这不是按顺序播放，而是用户在拖拽游标或者倒放，此时需要精准 Seek
-    Texture getFrame(const std::string& clipId, int64_t localTimeNs, bool requiresExactSeek = false);
+    ResultPayload<Texture> getFrame(const std::string& clipId, int64_t localTimeNs, bool requiresExactSeek = false);
 
     // [旧接口兼容] 默认顺序播放
-    Texture getFrame(const std::string& clipId, int64_t localTimeNs) override {
+    ResultPayload<Texture> getFrame(const std::string& clipId, int64_t localTimeNs) override {
         return getFrame(clipId, localTimeNs, false);
     }
 

--- a/core/src/timeline/Compositor.cpp
+++ b/core/src/timeline/Compositor.cpp
@@ -321,7 +321,11 @@ Result Compositor::renderFrameAtTime(int64_t timelineNs, FrameBufferPtr outputFb
         // Clamp local time to effective trim range
         localTimeNs = std::max(clip->getEffectiveTrimIn(), std::min(localTimeNs, clip->getEffectiveTrimOut()));
 
-        Texture fgTex = m_decoderPool->getFrame(clip->getId(), localTimeNs);
+        ResultPayload<Texture> frameRes = m_decoderPool->getFrame(clip->getId(), localTimeNs);
+        if (!frameRes.isOk()) {
+            return Result::error(frameRes.getErrorCode(), "Decoder failed for clip " + clip->getId() + ": " + frameRes.getMessage());
+        }
+        Texture fgTex = frameRes.getValue();
         if (fgTex.id == 0) {
             return Result::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Decoder returned invalid texture for clip: " + clip->getId());
         }

--- a/core/src/timeline/DecoderPool.cpp
+++ b/core/src/timeline/DecoderPool.cpp
@@ -122,13 +122,13 @@ void DecoderPool::evictDecodersIfNeeded() {
     }
 }
 
-Texture DecoderPool::getFrame(const std::string& clipId, int64_t localTimeNs, bool requiresExactSeek) {
+ResultPayload<Texture> DecoderPool::getFrame(const std::string& clipId, int64_t localTimeNs, bool requiresExactSeek) {
     std::unique_lock<std::mutex> lock(m_mutex);
 
     auto it = m_decoders.find(clipId);
     if (it == m_decoders.end()) {
         std::cerr << "[DecoderPool] Decoder context not found for clip " << clipId << std::endl;
-        return {0, 0, 0};
+        return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_CLIP_NOT_FOUND, "Decoder context not found for clip " + clipId);
     }
 
     auto ctx = it->second;
@@ -140,7 +140,11 @@ Texture DecoderPool::getFrame(const std::string& clipId, int64_t localTimeNs, bo
     if (useSoftwareDecoder) {
         if (!ctx->softDecoder) {
             ctx->softDecoder = createSoftwareDecoder();
-            ctx->softDecoder->open(ctx->sourcePath);
+            auto openRes = ctx->softDecoder->open(ctx->sourcePath);
+            if (!openRes.isOk()) {
+                std::cerr << "[DecoderPool] Failed to open Software Decoder for clip " << clipId << ": " << openRes.getMessage() << std::endl;
+                return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Failed to open software decoder");
+            }
             std::cout << "[DecoderPool] Falling back to Software Decoder for clip " << clipId << std::endl;
         }
         Result seekRes = ctx->softDecoder->seekExact(localTimeNs);
@@ -150,8 +154,13 @@ Texture DecoderPool::getFrame(const std::string& clipId, int64_t localTimeNs, bo
                 ctx->lastDecodedFrame = tex;
                 ctx->lastDecodedTimeNs = localTimeNs;
                 ctx->isInitialized = true;
+                return ResultPayload<Texture>::ok(tex);
             }
-            return ctx->lastDecodedFrame;
+            std::cerr << "[DecoderPool] Software decoder returned invalid texture for clip " << clipId << std::endl;
+            return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Software decoder returned invalid texture");
+        } else {
+            std::cerr << "[DecoderPool] Software seek failed for clip " << clipId << ": " << seekRes.getMessage() << std::endl;
+            return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Software seek failed: " + seekRes.getMessage());
         }
     }
 
@@ -165,10 +174,13 @@ Texture DecoderPool::getFrame(const std::string& clipId, int64_t localTimeNs, bo
                 m_activeDecoderCount++;
                 std::cout << "[DecoderPool] Activated decoder for clip " << clipId << std::endl;
             } else {
-                std::cerr << "[DecoderPool] Failed to activate decoder for clip " << clipId << std::endl;
+                std::cerr << "[DecoderPool] Failed to activate decoder for clip " << clipId << ": " << res.getMessage() << std::endl;
                 ctx->decoder = nullptr;
                 ctx->hwFailed = true; // 硬件解码器直接报废，未来全走软解
             }
+        } else {
+            std::cerr << "[DecoderPool] createPlatformDecoder returned null for clip " << clipId << std::endl;
+            ctx->hwFailed = true;
         }
     }
 
@@ -176,7 +188,7 @@ Texture DecoderPool::getFrame(const std::string& clipId, int64_t localTimeNs, bo
         // 先尝试精准 Seek，检查硬件解码器是否支持该跳变
         Result seekRes = ctx->decoder->seekExact(localTimeNs);
         if (!seekRes.isOk()) {
-            std::cerr << "[DecoderPool] Hardware seek failed: " << seekRes.getMessage() << std::endl;
+            std::cerr << "[DecoderPool] Hardware seek failed for clip " << clipId << ": " << seekRes.getMessage() << ". Degrading to software." << std::endl;
             // 硬件解码器寻址失败（如 B-Frame 导致花屏），触发当前上下文的硬件降级
             ctx->hwFailed = true;
             ctx->decoder->close();
@@ -194,16 +206,20 @@ Texture DecoderPool::getFrame(const std::string& clipId, int64_t localTimeNs, bo
             ctx->lastDecodedFrame = tex;
             ctx->lastDecodedTimeNs = localTimeNs;
             ctx->isInitialized = true;
+            return ResultPayload<Texture>::ok(tex);
+        } else {
+            // If HW decoder returns 0, it might be waiting for more data or failed.
+            // In a real NLE, we might want to return the last good frame or fail.
+            // Requirement says "explicit failure or clear degradation logs" and "no longer pretending to be successful".
+            // Returning the last frame could still be considered "pretending" if it's not what was requested.
+            // But if it's just slow, maybe it's fine? No, let's be strict if it returns 0.
+            std::cerr << "[DecoderPool] Hardware decoder returned invalid texture for clip " << clipId << std::endl;
+            return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Hardware decoder returned invalid texture");
         }
-        return ctx->lastDecodedFrame;
     } else {
-        // Fallback dummy logic if both fail
-        if (!ctx->isInitialized) {
-            ctx->lastDecodedFrame = {1, 1920, 1080}; // Dummy ID
-            ctx->isInitialized = true;
-        }
-        ctx->lastDecodedTimeNs = localTimeNs;
-        return ctx->lastDecodedFrame;
+        // Both HW and SW (if tried) failed, or we are in a state where we can't decode.
+        std::cerr << "[DecoderPool] Both HW and SW decoding failed or unavailable for clip " << clipId << std::endl;
+        return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Decoding failed or unavailable");
     }
 }
 

--- a/tests/test_decoder_pool.cpp
+++ b/tests/test_decoder_pool.cpp
@@ -64,21 +64,21 @@ void test_decoder_pool_lru_eviction() {
     pool.registerMedia("clip5", "v5.mp4");
 
     // Access 1-4 using the specific overload to avoid ambiguity in test
-    pool.getFrame("clip1", 0, false);
-    pool.getFrame("clip2", 0, false);
-    pool.getFrame("clip3", 0, false);
-    pool.getFrame("clip4", 0, false);
+    assert(pool.getFrame("clip1", 0, false).isOk());
+    assert(pool.getFrame("clip2", 0, false).isOk());
+    assert(pool.getFrame("clip3", 0, false).isOk());
+    assert(pool.getFrame("clip4", 0, false).isOk());
 
     assert(MockVideoDecoder::m_openCount == 4);
     assert(MockVideoDecoder::m_closeCount == 0);
 
     // Access 5, should evict clip1
-    pool.getFrame("clip5", 0, false);
+    assert(pool.getFrame("clip5", 0, false).isOk());
     assert(MockVideoDecoder::m_openCount == 5);
     assert(MockVideoDecoder::m_closeCount == 1);
 
     // Access 1 again, should evict clip2
-    pool.getFrame("clip1", 0, false);
+    assert(pool.getFrame("clip1", 0, false).isOk());
     assert(MockVideoDecoder::m_openCount == 6);
     assert(MockVideoDecoder::m_closeCount == 2);
 
@@ -93,7 +93,7 @@ void test_decoder_pool_release() {
     {
         DecoderPool pool;
         pool.registerMedia("clip1", "v1.mp4");
-        pool.getFrame("clip1", 0, false);
+        assert(pool.getFrame("clip1", 0, false).isOk());
         assert(MockVideoDecoder::m_openCount == 1);
 
         pool.releaseMedia("clip1");
@@ -112,14 +112,14 @@ void test_decoder_pool_re_register() {
 
     DecoderPool pool;
     pool.registerMedia("clip1", "v1.mp4");
-    pool.getFrame("clip1", 0, false);
+    assert(pool.getFrame("clip1", 0, false).isOk());
     assert(MockVideoDecoder::m_openCount == 1);
 
     // Re-register same clipId
     pool.registerMedia("clip1", "v1_new.mp4");
     assert(MockVideoDecoder::m_closeCount == 1);
 
-    pool.getFrame("clip1", 0, false);
+    assert(pool.getFrame("clip1", 0, false).isOk());
     assert(MockVideoDecoder::m_openCount == 2);
 
     std::cout << "test_decoder_pool_re_register passed" << std::endl;
@@ -133,8 +133,8 @@ void test_decoder_pool_clear() {
     DecoderPool pool;
     pool.registerMedia("clip1", "v1.mp4");
     pool.registerMedia("clip2", "v2.mp4");
-    pool.getFrame("clip1", 0, false);
-    pool.getFrame("clip2", 0, false);
+    assert(pool.getFrame("clip1", 0, false).isOk());
+    assert(pool.getFrame("clip2", 0, false).isOk());
     assert(MockVideoDecoder::m_openCount == 2);
 
     pool.clear();
@@ -154,15 +154,16 @@ void test_decoder_pool_stale_texture() {
     pool.registerMedia("clip3", "v3.mp4");
     pool.registerMedia("clip4", "v4.mp4");
 
-    Texture t1 = pool.getFrame("clip1", 0, false);
-    assert(t1.id != 0);
+    auto res1 = pool.getFrame("clip1", 0, false);
+    assert(res1.isOk());
+    assert(res1.getValue().id != 0);
 
     // Force eviction of clip1
     pool.registerMedia("clip5", "v5.mp4");
-    pool.getFrame("clip2", 0, false);
-    pool.getFrame("clip3", 0, false);
-    pool.getFrame("clip4", 0, false);
-    pool.getFrame("clip5", 0, false); // This should evict clip1
+    assert(pool.getFrame("clip2", 0, false).isOk());
+    assert(pool.getFrame("clip3", 0, false).isOk());
+    assert(pool.getFrame("clip4", 0, false).isOk());
+    assert(pool.getFrame("clip5", 0, false).isOk()); // This should evict clip1
 
     // Register clip1 again, it should have a fresh context or at least reset frame
     // Actually, eviction doesn't remove it from m_decoders, just closes the decoder.
@@ -187,7 +188,11 @@ void test_soft_decoder_lifecycle() {
     pool.registerMedia("clip1", "v1.mp4");
 
     // Request frame with exact seek to trigger soft decoder
-    pool.getFrame("clip1", 0, true);
+    // SoftwareVideoDecoder in VideoDecoder.h returns {0,0,0} from getFrameAt by default,
+    // which now triggers ERR_TIMELINE_DECODER_GET_FRAME_FAILED in DecoderPool.
+    auto res = pool.getFrame("clip1", 0, true);
+    assert(!res.isOk());
+    assert(res.getErrorCode() == ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED);
 
     // We can't easily check if softDecoder is open without making it accessible
     // but we can trust the code if it compiles and runs without crashing for now,


### PR DESCRIPTION
This change replaces the silent dummy texture fallback in the `DecoderPool` with explicit error reporting. The `IDecoderPool` interface now returns `ResultPayload<Texture>`, allowing callers like the `Compositor` to detect and propagate decoding failures. Dummy logic that returned a 1x1920x1080 texture has been removed, and clear error logs have been added for both hardware and software decoding failures. Unit tests and mocks have been updated to reflect these interface changes.

Fixes #91

---
*PR created automatically by Jules for task [16582444648745204154](https://jules.google.com/task/16582444648745204154) started by @zx2121651*