### PR TITLE
Stabilize iOS processFrame main path

### DIFF
--- a/ios/Classes/FilterEngine.swift
+++ b/ios/Classes/FilterEngine.swift
@@ -29,7 +29,11 @@ import OpenGLES
 
     // Call on GL thread to process frames from AVFoundation/Camera
     @objc public func processFrame(_ pixelBuffer: CVPixelBuffer) -> CVPixelBuffer? {
-        return wrapper.processFrame(pixelBuffer)?.takeUnretainedValue()
+        return wrapper.processFrame(pixelBuffer)?.takeRetainedValue()
+    }
+
+    @objc public var lastErrorCode: Int32 {
+        return wrapper.lastErrorCode
     }
 
     // Update float parameter on the fly

--- a/ios/Classes/FilterEngineWrapper.h
+++ b/ios/Classes/FilterEngineWrapper.h
@@ -13,6 +13,8 @@ typedef NS_ENUM(NSInteger, IOSFilterType) {
 
 @interface FilterEngineWrapper : NSObject
 
+@property (nonatomic, readonly) int lastErrorCode;
+
 - (instancetype)init;
 - (int)initializeWithContext:(EAGLContext *)context;
 - (CVPixelBufferRef)processFrame:(CVPixelBufferRef)pixelBuffer;

--- a/ios/Classes/FilterEngineWrapper.mm
+++ b/ios/Classes/FilterEngineWrapper.mm
@@ -11,6 +11,7 @@ using namespace sdk::video;
 
 @interface FilterEngineWrapper () {
     std::shared_ptr<FilterEngine> engine;
+    EAGLContext *m_context;
     CVOpenGLESTextureCacheRef textureCache;
     CVPixelBufferPoolRef pixelBufferPool;
     size_t poolWidth;
@@ -18,6 +19,7 @@ using namespace sdk::video;
     GLuint blitFboRead;
     GLuint blitFboDraw;
 }
+@property (nonatomic, readwrite) int lastErrorCode;
 @end
 
 @implementation FilterEngineWrapper
@@ -27,35 +29,54 @@ using namespace sdk::video;
     if (self) {
         engine = std::make_shared<FilterEngine>();
         engine->setAssetProvider(std::make_shared<IOSAssetProvider>());
+        m_context = nil;
         textureCache = NULL;
         pixelBufferPool = NULL;
         poolWidth = 0;
         poolHeight = 0;
         blitFboRead = 0;
         blitFboDraw = 0;
+        _lastErrorCode = 0;
     }
     return self;
 }
 
 - (int)initializeWithContext:(EAGLContext *)context {
-    if (!context || !engine) return static_cast<int>(sdk::video::ErrorCode::ERR_INIT_CONTEXT_FAILED);
+    if (!context || !engine) {
+        self.lastErrorCode = static_cast<int>(sdk::video::ErrorCode::ERR_INIT_CONTEXT_FAILED);
+        return self.lastErrorCode;
+    }
 
-    [EAGLContext setCurrentContext:context];
+    m_context = context;
+    [EAGLContext setCurrentContext:m_context];
 
-    CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, context, NULL, &textureCache);
+    if (textureCache) {
+        CFRelease(textureCache);
+        textureCache = NULL;
+    }
+
+    CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, m_context, NULL, &textureCache);
     if (err != kCVReturnSuccess) {
-        return static_cast<int>(sdk::video::ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED); // Texture cache creation failed
+        self.lastErrorCode = static_cast<int>(sdk::video::ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED);
+        return self.lastErrorCode;
     }
 
     Result res = engine->initialize();
     if (!res.isOk()) {
-        return res.getErrorCode() != 0 ? res.getErrorCode() : -2;
+        self.lastErrorCode = res.getErrorCode() != 0 ? res.getErrorCode() : -2;
+        return self.lastErrorCode;
     }
+    self.lastErrorCode = 0;
     return 0; // OK
 }
 
 - (CVPixelBufferRef)processFrame:(CVPixelBufferRef)pixelBuffer {
-    if (!engine || !textureCache || !pixelBuffer) return pixelBuffer;
+    if (!engine || !textureCache || !pixelBuffer || !m_context) {
+        self.lastErrorCode = static_cast<int>(sdk::video::ErrorCode::ERR_RENDER_INVALID_STATE);
+        return nil;
+    }
+
+    [EAGLContext setCurrentContext:m_context];
 
     size_t width = CVPixelBufferGetWidth(pixelBuffer);
     size_t height = CVPixelBufferGetHeight(pixelBuffer);
@@ -76,7 +97,8 @@ using namespace sdk::video;
                                                                 &cvTexture);
 
     if (err != kCVReturnSuccess || !cvTexture) {
-        return pixelBuffer;
+        self.lastErrorCode = static_cast<int>(sdk::video::ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED);
+        return nil;
     }
 
     GLuint inputTextureId = CVOpenGLESTextureGetName(cvTexture);
@@ -86,8 +108,9 @@ using namespace sdk::video;
     auto result = engine->processFrame(inTex, (int)width, (int)height);
     if (!result.isOk()) {
         NSLog(@"FilterEngineWrapper: processFrame failed [%d] %s", result.getErrorCode(), result.getMessage().c_str());
-        CVBufferRelease(cvTexture);
-        return nil; // Return nil so Swift bypasses or emits fallback
+        self.lastErrorCode = result.getErrorCode();
+        CFRelease(cvTexture);
+        return nil;
     }
 
     Texture outTex = result.getValue();
@@ -96,6 +119,7 @@ using namespace sdk::video;
     if (poolWidth != width || poolHeight != height || !pixelBufferPool) {
         if (pixelBufferPool) {
             CVPixelBufferPoolRelease(pixelBufferPool);
+            pixelBufferPool = NULL;
         }
         NSDictionary *pixelBufferAttributes = @{
             (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
@@ -104,7 +128,12 @@ using namespace sdk::video;
             (id)kCVPixelBufferOpenGLESCompatibilityKey: @(YES),
             (id)kCVPixelBufferIOSurfacePropertiesKey: @{}
         };
-        CVPixelBufferPoolCreate(kCFAllocatorDefault, NULL, (__bridge CFDictionaryRef)pixelBufferAttributes, &pixelBufferPool);
+        err = CVPixelBufferPoolCreate(kCFAllocatorDefault, NULL, (__bridge CFDictionaryRef)pixelBufferAttributes, &pixelBufferPool);
+        if (err != kCVReturnSuccess || !pixelBufferPool) {
+            self.lastErrorCode = static_cast<int>(sdk::video::ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED);
+            CFRelease(cvTexture);
+            return nil;
+        }
         poolWidth = width;
         poolHeight = height;
     }
@@ -112,8 +141,9 @@ using namespace sdk::video;
     CVPixelBufferRef outPixelBuffer = NULL;
     err = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pixelBufferPool, &outPixelBuffer);
     if (err != kCVReturnSuccess || !outPixelBuffer) {
+        self.lastErrorCode = static_cast<int>(sdk::video::ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED);
         CFRelease(cvTexture);
-        return pixelBuffer;
+        return nil;
     }
 
     CVOpenGLESTextureRef outCvTexture = NULL;
@@ -130,9 +160,10 @@ using namespace sdk::video;
                                                        0,
                                                        &outCvTexture);
     if (err != kCVReturnSuccess || !outCvTexture) {
+        self.lastErrorCode = static_cast<int>(sdk::video::ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED);
         CVPixelBufferRelease(outPixelBuffer);
         CFRelease(cvTexture);
-        return pixelBuffer;
+        return nil;
     }
 
     GLuint outputTextureId = CVOpenGLESTextureGetName(outCvTexture);
@@ -167,18 +198,21 @@ using namespace sdk::video;
     CFRelease(cvTexture);
     CVOpenGLESTextureCacheFlush(textureCache, 0);
 
-    // Return the new zero-copy buffer
+    // Return the new zero-copy buffer (Ownership is transferred to caller)
+    self.lastErrorCode = 0;
     return outPixelBuffer;
 }
 
 - (int)addFilter:(IOSFilterType)type {
     if (!engine) return static_cast<int>(sdk::video::ErrorCode::ERR_INIT_CONTEXT_FAILED);
+    if (m_context) [EAGLContext setCurrentContext:m_context];
     auto res = engine->addFilter(static_cast<sdk::video::FilterType>(type));
     return res.isOk() ? static_cast<int>(sdk::video::ErrorCode::SUCCESS) : res.getErrorCode();
 }
 
 - (int)removeAllFilters {
     if (!engine) return static_cast<int>(sdk::video::ErrorCode::ERR_INIT_CONTEXT_FAILED);
+    if (m_context) [EAGLContext setCurrentContext:m_context];
     auto res = engine->removeAllFilters();
     return res.isOk() ? static_cast<int>(sdk::video::ErrorCode::SUCCESS) : res.getErrorCode();
 }
@@ -196,6 +230,7 @@ using namespace sdk::video;
 }
 
 - (void)releaseResources {
+    if (m_context) [EAGLContext setCurrentContext:m_context];
     if (engine) {
         engine->release();
     }
@@ -215,6 +250,7 @@ using namespace sdk::video;
         glDeleteFramebuffers(1, &blitFboDraw);
         blitFboDraw = 0;
     }
+    m_context = nil;
 }
 
 - (NSArray<NSNumber *> *)getPerformanceMetrics {

--- a/ios/Classes/VideoFilterManager.swift
+++ b/ios/Classes/VideoFilterManager.swift
@@ -81,10 +81,16 @@ public actor VideoFilterManager {
      * - Parameter pixelBuffer: 相机硬件直出的原始视频帧
      */
     public func processFrame(_ pixelBuffer: CVPixelBuffer, timestamp: CMTime? = nil) {
+        let finalTimestamp = timestamp ?? CMClockGetTime(CMClockGetHostTimeClock())
+
         guard case .running = state else {
             // 降级策略：如果引擎未初始化或者崩溃，直接使用 yield 原样返回输入的 pixelBuffer，
             // 这确保了哪怕特效引擎坏了，用户的相机画面也不会黑屏 (Bypass 原图)。
             streamContinuation?.yield(.success(pixelBuffer))
+
+            if let encoder = videoEncoder, encoder.isRecording {
+                encoder.appendVideoPixelBuffer(pixelBuffer, timestamp: finalTimestamp)
+            }
             return
         }
 
@@ -94,15 +100,30 @@ public actor VideoFilterManager {
 
             // 如果正在录制，将处理后的帧写入编码器
             if let encoder = videoEncoder, encoder.isRecording {
-                // 使用传入的真实时间戳，或回退到系统时钟
-                let finalTimestamp = timestamp ?? CMClockGetTime(CMClockGetHostTimeClock())
                 encoder.appendVideoPixelBuffer(processedBuffer, timestamp: finalTimestamp)
             }
         } else {
             // 处理失败 (例如内部 simulateCrash 被触发，或者 GPU 显存耗尽)。
-            // 将状态标为 degraded，并 Bypass 原图。
-            self.state = .degraded
+            let errorCode = engine.lastErrorCode
+            handleError(Int(errorCode))
+
+            // Bypass 原图以防黑屏
             streamContinuation?.yield(.success(pixelBuffer))
+
+            if let encoder = videoEncoder, encoder.isRecording {
+                encoder.appendVideoPixelBuffer(pixelBuffer, timestamp: finalTimestamp)
+            }
+        }
+    }
+
+    private func handleError(_ errorCode: Int) {
+        // ERROR: fatal (-1000 to -1999)
+        // DEGRADED: recoverable (-2000 to -4999)
+        if errorCode <= -1000 && errorCode >= -1999 {
+            let error = NSError(domain: "VideoFilterManager", code: errorCode, userInfo: [NSLocalizedDescriptionKey: "Fatal engine error: \(errorCode)"])
+            self.state = .error(error)
+        } else if errorCode <= -2000 && errorCode >= -4999 {
+            self.state = .degraded
         }
     }
 


### PR DESCRIPTION
审查 iOS processFrame 主路径，确保初始化、处理和失败降级更可靠。处理失败不会轻易导致黑屏或不可恢复状态。修复了 CVPixelBuffer 的内存泄漏问题，并加强了 OpenGL Context 的线程安全性。

Fixes #94

---
*PR created automatically by Jules for task [3431050165879426856](https://jules.google.com/task/3431050165879426856) started by @zx2121651*