### PR TITLE
[iOS] Improve iOS recording timestamp monotonicity and reduce drift

### DIFF
--- a/ios/Classes/VideoEncoder.swift
+++ b/ios/Classes/VideoEncoder.swift
@@ -142,7 +142,13 @@ public class VideoEncoder {
         if audioInput.isReadyForMoreMediaData {
             var sbuf: CMSampleBuffer?
             var timing = CMSampleTimingInfo(duration: CMSampleBufferGetDuration(sampleBuffer), presentationTimeStamp: lastAudioPts, decodeTimeStamp: .invalid)
-            CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, sampleBuffer, 1, &timing, &sbuf)
+            CMSampleBufferCreateCopyWithNewTiming(
+                allocator: kCFAllocatorDefault,
+                sampleBuffer: sampleBuffer,
+                sampleTimingEntryCount: 1,
+                sampleTimingArray: &timing,
+                sampleBufferOut: &sbuf
+            )
 
             if let sbuf = sbuf {
                 audioInput.append(sbuf)

--- a/ios/Classes/VideoEncoder.swift
+++ b/ios/Classes/VideoEncoder.swift
@@ -20,12 +20,17 @@ public class VideoEncoder {
     private var startTime: CMTime = .zero
     private var lastVideoPts: CMTime = .zero
     private var lastAudioPts: CMTime = .zero
+    private var totalAudioSamplesEncoded: Int64 = 0
+    private let lock = NSRecursiveLock()
 
     public init(config: VideoExportConfig) {
         self.config = config
     }
 
     public func startRecording() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
         let outputURL = config.outputURL
         guard !isRecording else { throw VideoEncoderError.recordingAlreadyStarted }
 
@@ -72,8 +77,8 @@ public class VideoEncoder {
         let audioSettings: [String: Any] = [
             AVFormatIDKey: kAudioFormatMPEG4AAC,
             AVNumberOfChannelsKey: 2,
-            AVSampleRateKey: 44100,
-            AVEncoderBitRateKey: 128000
+            AVSampleRateKey: config.audioSampleRate,
+            AVEncoderBitRateKey: config.audioBitrate
         ]
 
         audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
@@ -86,9 +91,15 @@ public class VideoEncoder {
         assetWriter?.startWriting()
         isRecording = true
         isFirstFrame = true
+        lastVideoPts = .zero
+        lastAudioPts = .zero
+        totalAudioSamplesEncoded = 0
     }
 
     public func appendVideoPixelBuffer(_ pixelBuffer: CVPixelBuffer, timestamp: CMTime) {
+        lock.lock()
+        defer { lock.unlock() }
+
         guard isRecording, let assetWriter = assetWriter else { return }
         if assetWriter.status == .failed {
             stopRecording(isFallback: true)
@@ -102,8 +113,8 @@ public class VideoEncoder {
             startTime = safeTimestamp
             isFirstFrame = false
         } else if safeTimestamp <= lastVideoPts {
-            // A/V Sync monotonic enforcement
-            safeTimestamp = CMTimeAdd(lastVideoPts, CMTimeMake(value: 1, timescale: Int32(config.fps)))
+            // A/V Sync monotonic enforcement: ensure at least 0.1ms increment
+            safeTimestamp = CMTimeAdd(lastVideoPts, CMTime(value: 1, timescale: 10000))
         }
 
         lastVideoPts = safeTimestamp
@@ -113,22 +124,37 @@ public class VideoEncoder {
     }
 
     public func appendAudioSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
+        lock.lock()
+        defer { lock.unlock() }
+
         guard isRecording, let audioInput = audioInput, !isFirstFrame else { return }
 
-        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-        if pts <= lastAudioPts {
-            // Drop abnormal sample buffer to enforce strict monotonic timeline safely
-            return
+        // Audio drift prevention: Use cumulative sample count to calculate PTS
+        let audioPts = CMTimeAdd(startTime, CMTime(value: totalAudioSamplesEncoded, timescale: Int32(config.audioSampleRate)))
+
+        if audioPts <= lastAudioPts {
+            // Safety fallback to ensure monotonicity
+            lastAudioPts = CMTimeAdd(lastAudioPts, CMTime(value: 1, timescale: 10000))
+        } else {
+            lastAudioPts = audioPts
         }
-        lastAudioPts = pts
 
         if audioInput.isReadyForMoreMediaData {
-            audioInput.append(sampleBuffer)
+            var sbuf: CMSampleBuffer?
+            var timing = CMSampleTimingInfo(duration: CMSampleBufferGetDuration(sampleBuffer), presentationTimeStamp: lastAudioPts, decodeTimeStamp: .invalid)
+            CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, sampleBuffer, 1, &timing, &sbuf)
+
+            if let sbuf = sbuf {
+                audioInput.append(sbuf)
+                totalAudioSamplesEncoded += Int64(CMSampleBufferGetNumSamples(sampleBuffer))
+            }
         }
     }
 
     public func stopRecording(isFallback: Bool = false, completion: ((URL?) -> Void)? = nil) {
+        lock.lock()
         guard isRecording, let writer = assetWriter else {
+            lock.unlock()
             completion?(nil)
             return
         }
@@ -136,8 +162,10 @@ public class VideoEncoder {
         isRecording = false
         videoInput?.markAsFinished()
         audioInput?.markAsFinished()
+        lock.unlock()
 
-        writer.finishWriting {
+        writer.finishWriting { [weak self] in
+            guard let self = self else { return }
             DispatchQueue.main.async {
                 if writer.status == .completed && !isFallback {
                     completion?(writer.outputURL)
@@ -147,10 +175,12 @@ public class VideoEncoder {
                     completion?(nil)
                 }
 
+                self.lock.lock()
                 self.assetWriter = nil
                 self.videoInput = nil
                 self.audioInput = nil
                 self.pixelBufferAdaptor = nil
+                self.lock.unlock()
             }
         }
     }


### PR DESCRIPTION
This change improves the reliability of the iOS video recording path by addressing A/V synchronization and thread-safety issues in the `VideoEncoder` class.

Key improvements:
1. **Thread Safety**: Added `NSRecursiveLock` to synchronize access to `assetWriter`, `isRecording`, and other shared states across video, audio, and UI threads.
2. **Drift Prevention**: Switched audio PTS calculation from source timestamps to cumulative sample counts based on the configured sample rate. This ensures perfect alignment and zero drift relative to the recording start time.
3. **Monotonicity Enforcement**: Enhanced the video timestamp correction logic to ensure every frame has a strictly greater PTS (at least 0.1ms difference) than the previous one, preventing "illegal append" errors from `AVAssetWriter`.
4. **Lifecycle Hardening**: Improved `stopRecording` to immediately block further data appends and safely nil out resources in the `finishWriting` completion block.
5. **State Reset**: Fixed a potential issue where PTS state from a previous recording session could interfere with a new one.

Fixes #95

---
*PR created automatically by Jules for task [11251113181394353612](https://jules.google.com/task/11251113181394353612) started by @zx2121651*