### PR TITLE
Improve observability for render, decode, and export paths

### DIFF
--- a/core/include/Log.h
+++ b/core/include/Log.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+
+#ifdef __ANDROID__
+    #include <android/log.h>
+    #ifndef LOG_TAG
+        #define LOG_TAG "VideoSDK"
+    #endif
+    #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+    #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+    #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+    #define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
+#else
+    #include <cstdio>
+    #include <iostream>
+
+    #ifndef LOG_TAG
+        #define LOG_TAG "VideoSDK"
+    #endif
+
+    #define LOGI(...) do { printf("[INFO][%s] ", LOG_TAG); printf(__VA_ARGS__); printf("\n"); } while(0)
+    #define LOGE(...) do { fprintf(stderr, "[ERROR][%s] ", LOG_TAG); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } while(0)
+    #define LOGD(...) do { printf("[DEBUG][%s] ", LOG_TAG); printf(__VA_ARGS__); printf("\n"); } while(0)
+    #define LOGW(...) do { printf("[WARN][%s] ", LOG_TAG); printf(__VA_ARGS__); printf("\n"); } while(0)
+#endif

--- a/core/include/timeline/Compositor.h
+++ b/core/include/timeline/Compositor.h
@@ -3,6 +3,7 @@
 
 #include "../GLTypes.h"
 #include "../FrameBuffer.h"
+#include "../PerformanceMetrics.h"
 #include <memory>
 #include <vector>
 #include <functional>
@@ -29,7 +30,10 @@ public:
 
     Result renderFrameAtTime(int64_t timelineNs, FrameBufferPtr outputFb);
 
+    PerformanceMetrics getMetrics() const { return m_metricsCollector.getMetrics(); }
+
 private:
+    mutable MetricsCollector m_metricsCollector;
     std::shared_ptr<Timeline> m_timeline;
     std::shared_ptr<FilterEngine> m_filterEngine;
     std::shared_ptr<IDecoderPool> m_decoderPool;

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -1,5 +1,8 @@
 #include "../include/FilterEngine.h"
+#define LOG_TAG "FilterEngine"
+#include "../include/Log.h"
 #include <iostream>
+#include <chrono>
 #include <algorithm>
 
 namespace sdk {
@@ -53,6 +56,7 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
     }
 
     if (m_graph && m_outputNode) {
+        LOGD("Processing frame: input %u, size %dx%d", textureIn.id, width, height);
         if (m_cameraNode) {
             VideoFrame inFrame;
             inFrame.textureId = textureIn.id;
@@ -64,6 +68,7 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
 
         Result execRes = m_graph->execute(0);
         if (!execRes.isOk()) {
+            LOGE("Graph execution failed: %s", execRes.getMessage().c_str());
             return ResultPayload<Texture>::error(execRes.getErrorCode(), execRes.getMessage());
         }
 
@@ -74,6 +79,7 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
         m_metricsCollector.recordFrameTime(duration_ms);
 
         if (!outFrame.isValid()) {
+            LOGE("Pipeline produced an invalid output frame (missing texture)");
             return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Pipeline produced an invalid output frame (missing texture)");
         }
         return ResultPayload<Texture>::ok(Texture{outFrame.textureId, outFrame.width, outFrame.height});
@@ -242,9 +248,11 @@ Result FilterEngine::rebuildGraph(std::shared_ptr<PipelineNode> inputNode) {
     // Verify the new topology before committing
     Result res = newGraph->compile();
     if (!res.isOk()) {
-        std::cerr << "Pipeline Compile Failed during rebuild: " << res.getMessage() << std::endl;
+        LOGE("Pipeline Compile Failed during rebuild: %s", res.getMessage().c_str());
         return res;
     }
+
+    LOGI("Pipeline rebuilt successfully with %zu nodes", newGraph->getNodes().size());
 
     // Atomic commit of the new state
     if (m_graph) {

--- a/core/src/timeline/Compositor.cpp
+++ b/core/src/timeline/Compositor.cpp
@@ -1,7 +1,10 @@
 #include "../../include/FilterEngine.h"
 #include "../../include/timeline/Compositor.h"
 #include "../../include/GLStateManager.h"
+#define LOG_TAG "Compositor"
+#include "../../include/Log.h"
 #include <iostream>
+#include <chrono>
 
 namespace sdk {
 namespace video {
@@ -29,7 +32,7 @@ static GLuint compileShader(GLenum type, const char* s) {
     if (status != GL_TRUE) {
         char buf[512];
         glGetShaderInfoLog(sh, 512, NULL, buf);
-        std::cerr << "Compositor Shader Compile Error: " << buf << std::endl;
+        LOGE("Compositor Shader Compile Error: %s", buf);
         glDeleteShader(sh);
         return 0;
     }
@@ -43,8 +46,8 @@ static Result linkProgram(GLuint program) {
     if (status != GL_TRUE) {
         char buf[512];
         glGetProgramInfoLog(program, 512, NULL, buf);
-        std::cerr << "Compositor Program Link Error: " << buf << std::endl;
-        return Result::error(ErrorCode::ERR_TIMELINE_COMPOSITOR_INIT_FAILED, "Program link failed");
+        LOGE("Compositor Program Link Error: %s", buf);
+        return Result::error(ErrorCode::ERR_TIMELINE_COMPOSITOR_INIT_FAILED, "Program link failed: " + std::string(buf));
     }
     return Result::ok();
 }
@@ -287,6 +290,8 @@ Result Compositor::renderFrameAtTime(int64_t timelineNs, FrameBufferPtr outputFb
         return Result::error(ErrorCode::ERR_TIMELINE_NULL, "Compositor not properly initialized with Timeline/Engine/FBO");
     }
 
+    auto start_time = std::chrono::high_resolution_clock::now();
+
     Result res = initPrograms();
     if (!res.isOk()) return res;
 
@@ -297,6 +302,10 @@ Result Compositor::renderFrameAtTime(int64_t timelineNs, FrameBufferPtr outputFb
         glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);
         outputFb->unbind();
+
+        auto end_time = std::chrono::high_resolution_clock::now();
+        float duration_ms = std::chrono::duration<float, std::milli>(end_time - start_time).count();
+        m_metricsCollector.recordFrameTime(duration_ms);
         return Result::ok();
     }
 
@@ -314,6 +323,8 @@ Result Compositor::renderFrameAtTime(int64_t timelineNs, FrameBufferPtr outputFb
         return Result::error(ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED, "Failed to allocate ping/pong FBOs");
     }
 
+    LOGD("Compositing %zu clips at %lld", m_activeClips.size(), (long long)timelineNs);
+
     for (const auto& clip : m_activeClips) {
         int64_t clipRelativeNs = timelineNs - clip->getTimelineIn();
         int64_t localTimeNs = static_cast<int64_t>(clipRelativeNs * clip->getSpeed()) + clip->getEffectiveTrimIn();
@@ -323,6 +334,7 @@ Result Compositor::renderFrameAtTime(int64_t timelineNs, FrameBufferPtr outputFb
 
         ResultPayload<Texture> frameRes = m_decoderPool->getFrame(clip->getId(), localTimeNs);
         if (!frameRes.isOk()) {
+            LOGE("Decoder failed for clip %s at %lld: %s", clip->getId().c_str(), (long long)localTimeNs, frameRes.getMessage().c_str());
             return Result::error(frameRes.getErrorCode(), "Decoder failed for clip " + clip->getId() + ": " + frameRes.getMessage());
         }
         Texture fgTex = frameRes.getValue();
@@ -378,11 +390,17 @@ Result Compositor::renderFrameAtTime(int64_t timelineNs, FrameBufferPtr outputFb
 
     auto processResult = m_filterEngine->processFrame(accumulatedTexture, outputFb->width(), outputFb->height());
     if (!processResult.isOk()) {
+        LOGE("FilterEngine processFrame failed: %s", processResult.getMessage().c_str());
         return Result::error(processResult.getErrorCode(), processResult.getMessage());
     }
     Texture finalTex = processResult.getValue();
 
-    return copyTexture(finalTex, outputFb);
+    res = copyTexture(finalTex, outputFb);
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+    float duration_ms = std::chrono::duration<float, std::milli>(end_time - start_time).count();
+    m_metricsCollector.recordFrameTime(duration_ms);
+    return res;
 }
 
 } // namespace timeline

--- a/core/src/timeline/DecoderPool.cpp
+++ b/core/src/timeline/DecoderPool.cpp
@@ -1,4 +1,6 @@
 #include "../../include/timeline/DecoderPool.h"
+#define LOG_TAG "DecoderPool"
+#include "../../include/Log.h"
 #include <iostream>
 
 #ifdef __ANDROID__
@@ -49,7 +51,7 @@ void DecoderPool::registerMedia(const std::string& clipId, const std::string& so
     ctx->lastAccessCounter = ++m_accessCounter;
 
     m_decoders[clipId] = ctx;
-    std::cout << "[DecoderPool] Registered media " << clipId << " from " << sourcePath << " (deferred open)" << std::endl;
+    LOGI("Registered media %s from %s (deferred open)", clipId.c_str(), sourcePath.c_str());
 }
 
 void DecoderPool::releaseMedia(const std::string& clipId) {
@@ -70,7 +72,7 @@ void DecoderPool::releaseMedia(const std::string& clipId) {
         it->second->isInitialized = false;
 
         m_decoders.erase(it);
-        std::cout << "[DecoderPool] Released media " << clipId << std::endl;
+        LOGI("Released media %s", clipId.c_str());
     }
 }
 
@@ -91,7 +93,7 @@ void DecoderPool::clear() {
     }
     m_decoders.clear();
     m_activeDecoderCount = 0;
-    std::cout << "[DecoderPool] Cleared all media" << std::endl;
+    LOGI("Cleared all media");
 }
 
 void DecoderPool::evictDecodersIfNeeded() {
@@ -109,7 +111,7 @@ void DecoderPool::evictDecodersIfNeeded() {
         }
 
         if (oldestCtx) {
-            std::cout << "[DecoderPool] Evicting active decoder for clip " << oldestId << " due to concurrency limits." << std::endl;
+            LOGI("Evicting active decoder for clip %s due to concurrency limits.", oldestId.c_str());
             oldestCtx->decoder->close();
             oldestCtx->decoder = nullptr;
             oldestCtx->lastDecodedFrame = {0, 0, 0};
@@ -127,7 +129,7 @@ ResultPayload<Texture> DecoderPool::getFrame(const std::string& clipId, int64_t 
 
     auto it = m_decoders.find(clipId);
     if (it == m_decoders.end()) {
-        std::cerr << "[DecoderPool] Decoder context not found for clip " << clipId << std::endl;
+        LOGE("Decoder context not found for clip %s", clipId.c_str());
         return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_CLIP_NOT_FOUND, "Decoder context not found for clip " + clipId);
     }
 
@@ -142,10 +144,10 @@ ResultPayload<Texture> DecoderPool::getFrame(const std::string& clipId, int64_t 
             ctx->softDecoder = createSoftwareDecoder();
             auto openRes = ctx->softDecoder->open(ctx->sourcePath);
             if (!openRes.isOk()) {
-                std::cerr << "[DecoderPool] Failed to open Software Decoder for clip " << clipId << ": " << openRes.getMessage() << std::endl;
-                return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Failed to open software decoder: " + openRes.getMessage());
+                LOGE("Failed to open Software Decoder for clip %s: %s", clipId.c_str(), openRes.getMessage().c_str());
+                return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Failed to open software decoder for " + clipId + ": " + openRes.getMessage());
             }
-            std::cout << "[DecoderPool] Falling back to Software Decoder for clip " << clipId << std::endl;
+            LOGI("Falling back to Software Decoder for clip %s (HW failed: %d, Exact seek: %d)", clipId.c_str(), ctx->hwFailed, requiresExactSeek);
         }
         Result seekRes = ctx->softDecoder->seekExact(localTimeNs);
         if (seekRes.isOk()) {
@@ -157,11 +159,11 @@ ResultPayload<Texture> DecoderPool::getFrame(const std::string& clipId, int64_t 
                 ctx->isInitialized = true;
                 return frameRes;
             }
-            std::cerr << "[DecoderPool] Software decoder returned error for clip " << clipId << ": " << frameRes.getMessage() << std::endl;
+            LOGE("Software decoder returned error for clip %s at %lld: %s", clipId.c_str(), (long long)localTimeNs, frameRes.getMessage().c_str());
             return frameRes;
         } else {
-            std::cerr << "[DecoderPool] Software seek failed for clip " << clipId << ": " << seekRes.getMessage() << std::endl;
-            return ResultPayload<Texture>::error(ErrorCode::ERR_DECODER_SEEK_FAILED, "Software seek failed: " + seekRes.getMessage());
+            LOGE("Software seek failed for clip %s to %lld: %s", clipId.c_str(), (long long)localTimeNs, seekRes.getMessage().c_str());
+            return ResultPayload<Texture>::error(ErrorCode::ERR_DECODER_SEEK_FAILED, "Software seek failed for " + clipId + ": " + seekRes.getMessage());
         }
     }
 
@@ -173,14 +175,14 @@ ResultPayload<Texture> DecoderPool::getFrame(const std::string& clipId, int64_t 
             auto res = ctx->decoder->open(ctx->sourcePath);
             if (res.isOk()) {
                 m_activeDecoderCount++;
-                std::cout << "[DecoderPool] Activated decoder for clip " << clipId << std::endl;
+                LOGI("Activated hardware decoder for clip %s", clipId.c_str());
             } else {
-                std::cerr << "[DecoderPool] Failed to activate decoder for clip " << clipId << ": " << res.getMessage() << std::endl;
+                LOGE("Failed to activate hardware decoder for clip %s: %s", clipId.c_str(), res.getMessage().c_str());
                 ctx->decoder = nullptr;
                 ctx->hwFailed = true; // 硬件解码器直接报废，未来全走软解
             }
         } else {
-            std::cerr << "[DecoderPool] createPlatformDecoder returned null for clip " << clipId << std::endl;
+            LOGE("createPlatformDecoder returned null for clip %s", clipId.c_str());
             ctx->hwFailed = true;
         }
     }
@@ -189,7 +191,7 @@ ResultPayload<Texture> DecoderPool::getFrame(const std::string& clipId, int64_t 
         // 先尝试精准 Seek，检查硬件解码器是否支持该跳变
         Result seekRes = ctx->decoder->seekExact(localTimeNs);
         if (!seekRes.isOk()) {
-            std::cerr << "[DecoderPool] Hardware seek failed for clip " << clipId << ": " << seekRes.getMessage() << ". Degrading to software." << std::endl;
+            LOGW("Hardware seek failed for clip %s to %lld: %s. Degrading to software.", clipId.c_str(), (long long)localTimeNs, seekRes.getMessage().c_str());
             // 硬件解码器寻址失败（如 B-Frame 导致花屏），触发当前上下文的硬件降级
             ctx->hwFailed = true;
             ctx->decoder->close();
@@ -212,7 +214,7 @@ ResultPayload<Texture> DecoderPool::getFrame(const std::string& clipId, int64_t 
         } else {
             // 如果硬件解码器返回 Fatal 错误（比如设备丢失、解码器崩溃），触发降级
             if (frameRes.getErrorCode() == ErrorCode::ERR_DECODER_HW_FAILURE) {
-                std::cerr << "[DecoderPool] Hardware decoder fatal failure for clip " << clipId << ": " << frameRes.getMessage() << ". Degrading to software." << std::endl;
+                LOGE("Hardware decoder fatal failure for clip %s at %lld: %s. Degrading to software.", clipId.c_str(), (long long)localTimeNs, frameRes.getMessage().c_str());
                 ctx->hwFailed = true;
                 ctx->decoder->close();
                 ctx->decoder = nullptr;
@@ -223,13 +225,13 @@ ResultPayload<Texture> DecoderPool::getFrame(const std::string& clipId, int64_t 
             }
 
             // 否则可能是暂时性的丢帧 (ERR_DECODER_FRAME_DROP)
-            std::cerr << "[DecoderPool] Hardware decoder returned error for clip " << clipId << ": " << frameRes.getMessage() << std::endl;
+            LOGW("Hardware decoder returned error for clip %s at %lld: %s", clipId.c_str(), (long long)localTimeNs, frameRes.getMessage().c_str());
             return frameRes;
         }
     } else {
         // Both HW and SW (if tried) failed, or we are in a state where we can't decode.
-        std::cerr << "[DecoderPool] Both HW and SW decoding failed or unavailable for clip " << clipId << std::endl;
-        return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Decoding failed or unavailable");
+        LOGE("Both HW and SW decoding failed or unavailable for clip %s", clipId.c_str());
+        return ResultPayload<Texture>::error(ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED, "Decoding failed or unavailable for " + clipId);
     }
 }
 

--- a/core/src/timeline/TimelineExporterAndroid.cpp
+++ b/core/src/timeline/TimelineExporterAndroid.cpp
@@ -7,16 +7,15 @@
 #include <media/NdkMediaCodec.h>
 #include <media/NdkMediaFormat.h>
 #include <media/NdkMediaMuxer.h>
-#include <android/log.h>
+#define LOG_TAG "TimelineExporterAndroid"
+#include "../../include/Log.h"
 #include <android/native_window.h>
 #include <android/native_window_jni.h>
 #include <dlfcn.h>
 #include <thread>
+#include <chrono>
 #include <atomic>
 #include <mutex>
-
-#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, "TimelineExporterAndroid", __VA_ARGS__)
-#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, "TimelineExporterAndroid", __VA_ARGS__)
 
 // NDK constants missing in older headers or different names
 #ifndef AMEDIACODEC_BUFFER_FLAG_KEY_FRAME
@@ -45,8 +44,10 @@ public:
 
     Result configure(const std::string& outputPath, int width, int height, int fps, int bitrate) override {
         if (m_state != State::IDLE && m_state != State::COMPLETED && m_state != State::FAILED && m_state != State::CANCELED) {
+            LOGE("Cannot configure while running, current state: %d", (int)m_state.load());
             return Result::error(ErrorCode::ERR_EXPORTER_ALREADY_RUNNING, "Cannot configure while running");
         }
+        LOGI("Configuring exporter: path=%s, size=%dx%d, fps=%d, bitrate=%d", outputPath.c_str(), width, height, fps, bitrate);
         m_outputPath = outputPath;
         m_width = width;
         m_height = height;
@@ -68,10 +69,12 @@ public:
                      CompletionCallback onComplete) override {
 
         if (m_state == State::STARTING || m_state == State::EXPORTING) {
+            LOGE("Export already in progress, current state: %d", (int)m_state.load());
             return Result::error(ErrorCode::ERR_EXPORTER_ALREADY_RUNNING, "Export already in progress");
         }
 
         if (m_outputPath.empty() || m_width <= 0 || m_height <= 0) {
+            LOGE("Exporter not properly configured: path=%s, size=%dx%d", m_outputPath.c_str(), m_width, m_height);
             return Result::error(ErrorCode::ERR_EXPORTER_NOT_CONFIGURED, "Exporter not properly configured");
         }
 
@@ -83,16 +86,23 @@ public:
         }
 
         m_exportThread = std::thread([this, timeline, compositor, onProgress, onComplete]() {
+            auto start_time = std::chrono::high_resolution_clock::now();
+            LOGI("Export thread started");
             Result res = runExport(timeline, compositor, onProgress);
+            auto end_time = std::chrono::high_resolution_clock::now();
+            float total_duration_s = std::chrono::duration<float>(end_time - start_time).count();
 
             {
                 std::lock_guard<std::mutex> lock(m_stateMutex);
                 if (res.isOk()) {
                     m_state = State::COMPLETED;
+                    LOGI("Export completed successfully in %.2f seconds", total_duration_s);
                 } else if (res.getErrorCode() == ErrorCode::ERR_EXPORTER_CANCELLED) {
                     m_state = State::CANCELED;
+                    LOGI("Export canceled after %.2f seconds", total_duration_s);
                 } else {
                     m_state = State::FAILED;
+                    LOGE("Export failed after %.2f seconds: %s", total_duration_s, res.getMessage().c_str());
                 }
             }
 
@@ -262,6 +272,7 @@ private:
 
                 Result renderRes = compositor->renderFrameAtTime(currentTimeNs, screenFb);
                 if (!renderRes.isOk()) {
+                    LOGE("Export render failed at %lld: %s", (long long)currentTimeNs, renderRes.getMessage().c_str());
                     return renderRes;
                 }
 

--- a/core/src/timeline/TimelineExporterIOS.mm
+++ b/core/src/timeline/TimelineExporterIOS.mm
@@ -4,9 +4,12 @@
 #import <AVFoundation/AVFoundation.h>
 #import <CoreVideo/CoreVideo.h>
 #import <OpenGLES/EAGL.h>
+#define LOG_TAG "TimelineExporterIOS"
+#include "../../include/Log.h"
 #import <OpenGLES/ES3/gl.h>
 #include "../../include/GLStateManager.h"
 #include <thread>
+#include <chrono>
 #include <atomic>
 #include <mutex>
 
@@ -29,8 +32,10 @@ public:
 
     Result configure(const std::string& outputPath, int width, int height, int fps, int bitrate) override {
         if (m_state != State::IDLE && m_state != State::COMPLETED && m_state != State::FAILED && m_state != State::CANCELED) {
+            LOGE("Cannot configure while running, current state: %d", (int)m_state.load());
             return Result::error(ErrorCode::ERR_EXPORTER_ALREADY_RUNNING, "Cannot configure while running");
         }
+        LOGI("Configuring exporter: path=%s, size=%dx%d, fps=%d, bitrate=%d", outputPath.c_str(), width, height, fps, bitrate);
         m_outputPath = outputPath;
         m_width = width;
         m_height = height;
@@ -52,10 +57,12 @@ public:
                      CompletionCallback onComplete) override {
 
         if (m_state == State::STARTING || m_state == State::EXPORTING) {
+            LOGE("Export already in progress, current state: %d", (int)m_state.load());
             return Result::error(ErrorCode::ERR_EXPORTER_ALREADY_RUNNING, "Export already in progress");
         }
 
         if (m_outputPath.empty() || m_width <= 0 || m_height <= 0) {
+            LOGE("Exporter not properly configured: path=%s, size=%dx%d", m_outputPath.c_str(), m_width, m_height);
             return Result::error(ErrorCode::ERR_EXPORTER_NOT_CONFIGURED, "Exporter not properly configured");
         }
 
@@ -67,16 +74,23 @@ public:
         }
 
         m_exportThread = std::thread([this, timeline, compositor, onProgress, onComplete]() {
+            auto start_time = std::chrono::high_resolution_clock::now();
+            LOGI("Export thread started (iOS)");
             Result res = runExport(timeline, compositor, onProgress);
+            auto end_time = std::chrono::high_resolution_clock::now();
+            float total_duration_s = std::chrono::duration<float>(end_time - start_time).count();
 
             {
                 std::lock_guard<std::mutex> lock(m_stateMutex);
                 if (res.isOk()) {
                     m_state = State::COMPLETED;
+                    LOGI("Export completed successfully in %.2f seconds", total_duration_s);
                 } else if (res.getErrorCode() == ErrorCode::ERR_EXPORTER_CANCELLED) {
                     m_state = State::CANCELED;
+                    LOGI("Export canceled after %.2f seconds", total_duration_s);
                 } else {
                     m_state = State::FAILED;
+                    LOGE("Export failed after %.2f seconds: %s", total_duration_s, res.getMessage().c_str());
                 }
             }
 
@@ -226,6 +240,7 @@ private:
 
                         Result renderRes = compositor->renderFrameAtTime(currentTimeNs, cvExternalFbWrapper);
                         if (!renderRes.isOk()) {
+                            LOGE("Export render failed at %lld: %s", (long long)currentTimeNs, renderRes.getMessage().c_str());
                             exportResult = renderRes;
                             CFRelease(cvTexture);
                             CVPixelBufferRelease(pixelBuffer);

--- a/core/src/timeline/VideoDecoderAndroid.cpp
+++ b/core/src/timeline/VideoDecoderAndroid.cpp
@@ -4,7 +4,8 @@
 #include <media/NdkMediaExtractor.h>
 #include <media/NdkMediaCodec.h>
 #include <media/NdkMediaFormat.h>
-#include <android/log.h>
+#define LOG_TAG "VideoDecoderAndroid"
+#include "../../include/Log.h"
 #include <vector>
 #include <thread>
 #include <mutex>
@@ -12,8 +13,6 @@
 #include <queue>
 #include <atomic>
 #include "../../include/GLStateManager.h"
-
-#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, "VideoDecoderAndroid", __VA_ARGS__)
 
 namespace sdk {
 namespace video {
@@ -31,12 +30,12 @@ public:
 
     Result open(const std::string& filePath) override {
         m_extractor = AMediaExtractor_new();
-        if (!m_extractor) return Result::error(-4001, "Failed to create AMediaExtractor");
+        if (!m_extractor) return Result::error(-4001, "Failed to create AMediaExtractor for " + filePath);
 
         media_status_t err = AMediaExtractor_setDataSource(m_extractor, filePath.c_str());
         if (err != AMEDIA_OK) {
-            LOGE("Failed to set data source: %s", filePath.c_str());
-            return Result::error(-4002, "Failed to set data source");
+            LOGE("Failed to set data source: %s, error: %d", filePath.c_str(), (int)err);
+            return Result::error(-4002, "Failed to set data source for " + filePath);
         }
 
         int numTracks = AMediaExtractor_getTrackCount(m_extractor);
@@ -54,24 +53,34 @@ public:
             format = nullptr;
         }
 
-        if (!format) return Result::error(-4003, "No video track found");
+        if (!format) {
+            LOGE("No video track found in %s", filePath.c_str());
+            return Result::error(-4003, "No video track found in " + filePath);
+        }
 
         AMediaFormat_getInt32(format, AMEDIAFORMAT_KEY_WIDTH, &m_width);
         AMediaFormat_getInt32(format, AMEDIAFORMAT_KEY_HEIGHT, &m_height);
 
         m_codec = AMediaCodec_createDecoderByType(mime);
         if (!m_codec) {
+            LOGE("Failed to create codec for mime %s", mime);
             AMediaFormat_delete(format);
-            return Result::error(-4004, "Failed to create codec");
+            return Result::error(-4004, "Failed to create codec for " + filePath);
         }
 
         err = AMediaCodec_configure(m_codec, format, nullptr, nullptr, 0); // ByteBuffer mode
         AMediaFormat_delete(format);
 
-        if (err != AMEDIA_OK) return Result::error(-4005, "Failed to configure codec");
+        if (err != AMEDIA_OK) {
+            LOGE("Failed to configure codec for %s, error: %d", filePath.c_str(), (int)err);
+            return Result::error(-4005, "Failed to configure codec for " + filePath);
+        }
 
         err = AMediaCodec_start(m_codec);
-        if (err != AMEDIA_OK) return Result::error(-4006, "Failed to start codec");
+        if (err != AMEDIA_OK) {
+            LOGE("Failed to start codec for %s, error: %d", filePath.c_str(), (int)err);
+            return Result::error(-4006, "Failed to start codec for " + filePath);
+        }
 
         m_running = true;
         m_decodeThread = std::thread(&VideoDecoderAndroid::decodeLoop, this);
@@ -222,12 +231,14 @@ public:
         // 模拟：如果是需要倒放或跨越度太大的 Seek，硬件解码器宣布失败，交给软解。
         // （在真正的实现里，判断 timeNs 是否导致解码器丢帧或花屏）
         if (timeNs < m_lastSeekTimeNs) {
-            return Result::error(ErrorCode::ERR_DECODER_SEEK_FAILED, "Hardware Decoder failed to seek backward accurately (B-Frame Nightmare). Trigger Software Decoder fallback.");
+            LOGW("Backward seek detected (last: %lld, target: %lld). HW decoder may jitter.", (long long)m_lastSeekTimeNs, (long long)timeNs);
+            return Result::error(ErrorCode::ERR_DECODER_SEEK_FAILED, "Hardware Decoder failed to seek backward accurately. Trigger Software Decoder fallback.");
         }
 
         flushQueue();
         media_status_t status = AMediaExtractor_seekTo(m_extractor, timeNs / 1000, AMEDIAEXTRACTOR_SEEK_PREVIOUS_SYNC);
         if (status != AMEDIA_OK) {
+            LOGE("AMediaExtractor_seekTo failed, status: %d", (int)status);
             return Result::error(ErrorCode::ERR_DECODER_SEEK_FAILED, "AMediaExtractor_seekTo failed");
         }
 
@@ -258,6 +269,7 @@ public:
             int uvSize = m_width * m_height / 2;
 
             if (targetPacket->data.size() < ySize + uvSize) {
+                LOGE("Invalid frame data size: %zu, expected: %d", targetPacket->data.size(), ySize + uvSize);
                 return ResultPayload<Texture>::error(ErrorCode::ERR_DECODER_HW_FAILURE, "Invalid frame data size");
             }
 
@@ -294,6 +306,7 @@ public:
             return ResultPayload<Texture>::ok({m_textureId, (uint32_t)m_width, (uint32_t)m_height});
         }
 
+        LOGW("Frame not ready or dropped at %lld", (long long)timeNs);
         return ResultPayload<Texture>::error(ErrorCode::ERR_DECODER_FRAME_DROP, "Frame not ready or dropped");
     }
 

--- a/core/src/timeline/VideoDecoderIOS.mm
+++ b/core/src/timeline/VideoDecoderIOS.mm
@@ -3,6 +3,8 @@
 #ifdef __APPLE__
 #import <AVFoundation/AVFoundation.h>
 #import <CoreVideo/CoreVideo.h>
+#define LOG_TAG "VideoDecoderIOS"
+#include "../../include/Log.h"
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -29,12 +31,14 @@ public:
         NSError* error = nil;
         m_assetReader = [[AVAssetReader alloc] initWithAsset:asset error:&error];
         if (error) {
-            return Result::error(-4001, "Failed to create AVAssetReader");
+            LOGE("Failed to create AVAssetReader for %s, error: %s", filePath.c_str(), [[error localizedDescription] UTF8String]);
+            return Result::error(-4001, "Failed to create AVAssetReader for " + filePath);
         }
 
         NSArray<AVAssetTrack*>* tracks = [asset tracksWithMediaType:AVMediaTypeVideo];
         if (tracks.count == 0) {
-            return Result::error(-4003, "No video track found");
+            LOGE("No video track found in %s", filePath.c_str());
+            return Result::error(-4003, "No video track found in " + filePath);
         }
         AVAssetTrack* videoTrack = tracks.firstObject;
 
@@ -52,16 +56,19 @@ public:
         if ([m_assetReader canAddOutput:m_trackOutput]) {
             [m_assetReader addOutput:m_trackOutput];
         } else {
-            return Result::error(-4004, "Cannot add track output");
+            LOGE("Cannot add track output for %s", filePath.c_str());
+            return Result::error(-4004, "Cannot add track output for " + filePath);
         }
 
         EAGLContext* context = [EAGLContext currentContext];
         if (!context) {
+            LOGE("No EAGLContext available for %s", filePath.c_str());
             return Result::error(-4005, "No EAGLContext available");
         }
 
         CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, context, NULL, &m_textureCache);
         if (err != kCVReturnSuccess) {
+            LOGE("Failed to create texture cache for %s, error: %d", filePath.c_str(), err);
             return Result::error(-4006, "Failed to create texture cache");
         }
 
@@ -120,7 +127,8 @@ public:
         // 模拟: iOS AVAssetReader 不能随意 Seek，只能重新实例化并指定 timeRange
         // 因此如果需要精准回退，通常非常昂贵，触发软解降级
         if (timeNs < m_lastSeekTimeNs) {
-            return Result::error(ErrorCode::ERR_DECODER_SEEK_FAILED, "Hardware Decoder failed to seek backward accurately (B-Frame Nightmare). Trigger Software Decoder fallback.");
+            LOGW("Backward seek detected on iOS (last: %lld, target: %lld). HW decoder will fallback.", (long long)m_lastSeekTimeNs, (long long)timeNs);
+            return Result::error(ErrorCode::ERR_DECODER_SEEK_FAILED, "Hardware Decoder failed to seek backward accurately. Trigger Software Decoder fallback.");
         }
 
         flushQueue();
@@ -147,6 +155,7 @@ public:
         if (targetPacket && m_textureCache) {
             CVPixelBufferRef pixelBuffer = (CVPixelBufferRef)targetPacket->nativeBuffer;
             if (!pixelBuffer) {
+                LOGE("Invalid native buffer at %lld", (long long)timeNs);
                 return ResultPayload<Texture>::error(ErrorCode::ERR_DECODER_FRAME_DROP, "Invalid native buffer");
             }
 
@@ -174,10 +183,12 @@ public:
                 GLuint textureId = CVOpenGLESTextureGetName(m_cvTexture);
                 return ResultPayload<Texture>::ok({textureId, (uint32_t)m_width, (uint32_t)m_height});
             } else {
+                LOGE("Failed to create texture from CVPixelBuffer, error: %d", err);
                 return ResultPayload<Texture>::error(ErrorCode::ERR_DECODER_HW_FAILURE, "Failed to create texture from CVPixelBuffer");
             }
         }
 
+        LOGW("Frame not ready or dropped on iOS at %lld", (long long)timeNs);
         return ResultPayload<Texture>::error(ErrorCode::ERR_DECODER_FRAME_DROP, "Frame not ready or dropped");
     }
 


### PR DESCRIPTION
This change improves the observability of the Video SDK by unifying the logging system and adding performance metrics across the core rendering, decoding, and exporting pipelines.

Key improvements:
1.  **Unified Logging:** Introduced `core/include/Log.h` providing `LOGI`, `LOGE`, `LOGD`, and `LOGW` macros. It uses `__android_log_print` on Android and `printf`/`fprintf` on other platforms, including `LOG_TAG` for easier filtering.
2.  **Render Path:** Added logs for frame processing and pipeline rebuilding in `FilterEngine`. Added composition timing and shader/program failure logs in `Compositor`.
3.  **Decode Path:** Enhanced logs for decoder registration, activation, eviction, and failure in `DecoderPool`. Improved platform decoder logs for hardware/seek failures.
4.  **Export Path:** Added performance tracking (total time) and terminal state logs for export tasks on both Android and iOS.
5.  **Error Propagation:** Updated `Result::error` calls across these paths to include helpful context like file paths and clip IDs.
6.  **Code Hardening:** Addressed code review feedback by using `do { ... } while(0)` for macros and explicitly including `<chrono>`.

Fixes #97

---
*PR created automatically by Jules for task [4595858165179657668](https://jules.google.com/task/4595858165179657668) started by @zx2121651*