### PR TITLE
ci: use committed gradle wrapper in android workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,10 +22,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Generate Gradle Wrapper
-        working-directory: ./
-        run: gradle wrapper --gradle-version 8.8
-
+      # Use the committed Gradle Wrapper to ensure consistency between local and CI environments.
       - name: Build Android Library
         working-directory: ./
         run: ./gradlew :android:assembleDebug --stacktrace


### PR DESCRIPTION
Removed the dynamic gradle wrapper generation step from the Android CI workflow. The CI now strictly uses the committed gradlew from the repository root to ensure consistency between local and CI environments. Added a comment explaining this choice.

Fixes #131

---
*PR created automatically by Jules for task [501958733432207288](https://jules.google.com/task/501958733432207288) started by @zx2121651*