### PR TITLE
Enhance Android Unit Test Reporting and Artifact Retention

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,6 +36,15 @@ jobs:
         working-directory: ./
         run: ./gradlew :android:testDebugUnitTest --stacktrace
 
+      - name: "SDK Library: Upload Test Report"
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: android-test-reports
+          path: |
+            android/build/reports/tests/testDebugUnitTest/
+            android/build/test-results/testDebugUnitTest/
+
       # Step 3: Build the Sample App (Integration Verification)
       # This verifies that the SDK can be correctly integrated into a host application.
       # This step depends on the success of the SDK Library build.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,18 @@ android {
 
         viewBinding true
     }
+
+    testOptions {
+        unitTests.all {
+            testLogging {
+                events "passed", "skipped", "failed", "standardOut", "standardError"
+                exceptionFormat "full"
+                showCauses true
+                showExceptions true
+                showStackTraces true
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This change improves the observability of Android unit tests in the CI pipeline. It ensures that test failures are immediately actionable through detailed console logs and that full HTML/XML reports are preserved as downloadable artifacts for deeper analysis, even when the build fails.

Fixes #134

---
*PR created automatically by Jules for task [4515480065095642841](https://jules.google.com/task/4515480065095642841) started by @zx2121651*