### PR TITLE
[Tests][Core] Add FilterEngine initialize-release-reinitialize regression test

### DIFF
--- a/tests/FilterEngineTestAccessor.h
+++ b/tests/FilterEngineTestAccessor.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "../core/include/FilterEngine.h"
+
+namespace sdk {
+namespace video {
+
+class FilterEngineTestAccessor {
+public:
+    static bool isInitialized(const FilterEngine& engine) {
+        return engine.m_initialized;
+    }
+    static bool isGraphDirty(const FilterEngine& engine) {
+        return engine.m_isGraphDirty;
+    }
+    static std::shared_ptr<PipelineGraph> getGraph(const FilterEngine& engine) {
+        return engine.m_graph;
+    }
+    static std::shared_ptr<CameraInputNode> getCameraNode(const FilterEngine& engine) {
+        return engine.m_cameraNode;
+    }
+    static std::shared_ptr<OutputNode> getOutputNode(const FilterEngine& engine) {
+        return engine.m_outputNode;
+    }
+    static MetricsCollector& getMetricsCollector(FilterEngine& engine) {
+        return engine.m_metricsCollector;
+    }
+
+    // Setters used by existing tests
+    static void setOutputNode(FilterEngine& engine, std::shared_ptr<OutputNode> node) {
+        engine.m_outputNode = node;
+    }
+    static void setInitialized(FilterEngine& engine, bool initialized) {
+        engine.m_initialized = initialized;
+    }
+    static void setGraphDirty(FilterEngine& engine, bool dirty) {
+        engine.m_isGraphDirty = dirty;
+    }
+};
+
+} // namespace video
+} // namespace sdk

--- a/tests/test_filter_graph.cpp
+++ b/tests/test_filter_graph.cpp
@@ -7,25 +7,9 @@
 #include "../core/include/Filters.h"
 #include "../core/include/pipeline/PipelineGraph.h"
 #include "../core/include/pipeline/Nodes.h"
+#include "FilterEngineTestAccessor.h"
 
 using namespace sdk::video;
-
-namespace sdk {
-namespace video {
-class FilterEngineTestAccessor {
-public:
-    static void setOutputNode(FilterEngine& engine, std::shared_ptr<OutputNode> node) {
-        engine.m_outputNode = node;
-    }
-    static void setInitialized(FilterEngine& engine, bool initialized) {
-        engine.m_initialized = initialized;
-    }
-    static void setGraphDirty(FilterEngine& engine, bool dirty) {
-        engine.m_isGraphDirty = dirty;
-    }
-};
-}
-}
 
 class FailureFilter : public Filter {
 public:

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -4,8 +4,53 @@
 #include <memory>
 #include "../core/include/FilterEngine.h"
 #include "../core/include/Filters.h"
+#include "FilterEngineTestAccessor.h"
 
 using namespace sdk::video;
+
+void test_reinitialize_regression() {
+    FilterEngine engine;
+
+    std::cout << "1. Initial state check..." << std::endl;
+    assert(!FilterEngineTestAccessor::isInitialized(engine));
+    assert(FilterEngineTestAccessor::isGraphDirty(engine));
+
+    std::cout << "2. Initialize and build pipeline..." << std::endl;
+    Result res = engine.initialize();
+    assert(res.isOk());
+    assert(FilterEngineTestAccessor::isInitialized(engine));
+
+    res = engine.buildCameraPipeline();
+    assert(res.isOk());
+    assert(FilterEngineTestAccessor::getGraph(engine) != nullptr);
+    assert(FilterEngineTestAccessor::getCameraNode(engine) != nullptr);
+    assert(FilterEngineTestAccessor::getOutputNode(engine) != nullptr);
+
+    std::cout << "3. Record metrics..." << std::endl;
+    FilterEngineTestAccessor::getMetricsCollector(engine).recordFrameTime(16.6f);
+    assert(engine.getPerformanceMetrics().averageFrameTimeMs > 0);
+
+    std::cout << "4. Release and check state reset..." << std::endl;
+    engine.release();
+
+    assert(!FilterEngineTestAccessor::isInitialized(engine));
+    assert(FilterEngineTestAccessor::getGraph(engine) == nullptr);
+    assert(FilterEngineTestAccessor::getCameraNode(engine) == nullptr);
+    assert(FilterEngineTestAccessor::getOutputNode(engine) == nullptr);
+    assert(FilterEngineTestAccessor::isGraphDirty(engine));
+    assert(engine.getPerformanceMetrics().averageFrameTimeMs == 0.0f);
+
+    std::cout << "5. Re-initialize and rebuild..." << std::endl;
+    res = engine.initialize();
+    assert(res.isOk());
+    assert(FilterEngineTestAccessor::isInitialized(engine));
+
+    res = engine.buildCameraPipeline();
+    assert(res.isOk());
+    assert(FilterEngineTestAccessor::getGraph(engine) != nullptr);
+
+    std::cout << "test_reinitialize_regression passed" << std::endl;
+}
 
 void test_repeated_init_release() {
     FilterEngine engine;
@@ -69,6 +114,7 @@ void test_lifecycle_functionality() {
 }
 
 int main() {
+    test_reinitialize_regression();
     test_repeated_init_release();
     test_lifecycle_functionality();
     return 0;


### PR DESCRIPTION
This change adds a thorough regression test for the FilterEngine lifecycle (initialize -> release -> reinitialize) in tests/test_lifecycle.cpp. It also refactors the FilterEngineTestAccessor into a shared header to allow consistent internal state inspection across different test files.

Fixes #141

---
*PR created automatically by Jules for task [6673296387211580067](https://jules.google.com/task/6673296387211580067) started by @zx2121651*