### PR TITLE
Add regression tests for FilterEngine rebuildGraph transaction semantics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_test(NAME test_track_behavior COMMAND test_track_behavior)
 
 add_executable(test_rebuild_harden tests/test_rebuild_harden.cpp tests/mocks/MockCompositor.cpp)
 target_link_libraries(test_rebuild_harden video_sdk_core)
+add_test(NAME test_rebuild_harden COMMAND test_rebuild_harden)
 
 add_executable(test_timeline_node_harden tests/test_timeline_node_harden.cpp tests/mocks/MockCompositor.cpp)
 target_link_libraries(test_timeline_node_harden video_sdk_core)

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -187,8 +187,8 @@ Result FilterEngine::updateShaderSource(const std::string& name, const std::stri
 }
 
 Result FilterEngine::buildCameraPipeline() {
-    m_cameraNode = std::make_shared<CameraInputNode>("Camera");
-    return rebuildGraph(m_cameraNode);
+    auto cameraNode = std::make_shared<CameraInputNode>("Camera");
+    return rebuildGraph(cameraNode);
 }
 
 Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> timeline, std::shared_ptr<timeline::Compositor> compositor) {

--- a/tests/test_rebuild_harden.cpp
+++ b/tests/test_rebuild_harden.cpp
@@ -2,87 +2,140 @@
 #include <iostream>
 #include <cassert>
 #include <memory>
+#include <algorithm>
 #include "../core/include/FilterEngine.h"
 #include "../core/include/pipeline/Nodes.h"
+#include "FilterEngineTestAccessor.h"
 
 using namespace sdk::video;
 
-namespace sdk {
-namespace video {
-// Helper to access private members for testing
-class FilterEngineTestAccessor {
+class ToggledFailureFilter : public Filter {
 public:
-    static std::shared_ptr<PipelineGraph> getGraph(FilterEngine& engine) {
-        return engine.m_graph;
+    bool shouldFail = false;
+    std::string getFragmentShaderName() const override { return "toggled.frag"; }
+    Result initialize() override {
+        if (shouldFail) {
+            return Result::error(ErrorCode::ERR_INIT_SHADER_FAILED, "Intentional failure");
+        }
+        return Result::ok();
     }
-
-    static std::shared_ptr<CameraInputNode> getCameraNode(FilterEngine& engine) {
-        return engine.m_cameraNode;
-    }
-
-    static std::shared_ptr<OutputNode> getOutputNode(FilterEngine& engine) {
-        return engine.m_outputNode;
-    }
+protected:
+    void onDraw(const Texture&, FrameBufferPtr) override {}
+    std::string getFragmentShaderSource() const override { return ""; }
 };
-}
-}
 
-using namespace sdk::video;
-
-void test_camera_to_timeline_transition() {
+void test_rebuild_success() {
     FilterEngine engine;
     engine.initialize();
 
-    // 1. Initially it should be in camera mode (by default when buildCameraPipeline is called)
-    engine.buildCameraPipeline();
-    assert(FilterEngineTestAccessor::getCameraNode(engine) != nullptr);
+    auto filter1 = std::make_shared<ToggledFailureFilter>();
+    auto filter2 = std::make_shared<ToggledFailureFilter>();
+    engine.addFilterRaw(filter1);
+    engine.addFilterRaw(filter2);
 
-    // 2. Switch to timeline mode
-    engine.buildTimelinePipeline(nullptr, nullptr);
+    Result res = engine.buildCameraPipeline();
+    assert(res.isOk());
 
-    // 3. Verify camera node is cleared
-    assert(FilterEngineTestAccessor::getCameraNode(engine) == nullptr);
-    assert(FilterEngineTestAccessor::getOutputNode(engine) != nullptr);
+    auto graph = FilterEngineTestAccessor::getGraph(engine);
+    auto camera = FilterEngineTestAccessor::getCameraNode(engine);
+    auto output = FilterEngineTestAccessor::getOutputNode(engine);
 
-    std::cout << "test_camera_to_timeline_transition passed" << std::endl;
+    assert(graph != nullptr);
+    assert(camera != nullptr);
+    assert(output != nullptr);
+
+    // Verify graph contains these nodes
+    auto nodes = graph->getNodes();
+    assert(std::find(nodes.begin(), nodes.end(), camera) != nodes.end());
+    assert(std::find(nodes.begin(), nodes.end(), output) != nodes.end());
+
+    // Should have 4 nodes: Camera, Output, Filter1, Filter2 (due to implementation order in rebuildGraph)
+    assert(nodes.size() == 4);
+
+    // Verify topology: camera -> filter1 -> filter2 -> output
+    // Based on FilterEngine.cpp:
+    // newGraph->addNode(inputNode); // index 0
+    // newGraph->addNode(newOutputNode); // index 1
+    // for filters: newGraph->addNode(filterNode); // index 2, 3...
+
+    auto f1Node = std::dynamic_pointer_cast<FilterNode>(nodes[2]);
+    auto f2Node = std::dynamic_pointer_cast<FilterNode>(nodes[3]);
+    assert(f1Node && f1Node->getFilter() == filter1);
+    assert(f2Node && f2Node->getFilter() == filter2);
+
+    assert(camera->getOutputs().size() == 1);
+    assert(camera->getOutputs()[0] == f1Node);
+    assert(f1Node->getOutputs().size() == 1);
+    assert(f1Node->getOutputs()[0] == f2Node);
+    assert(f2Node->getOutputs().size() == 1);
+    assert(f2Node->getOutputs()[0] == output);
+
+    std::cout << "test_rebuild_success passed" << std::endl;
 }
 
-void test_transactional_rebuild_failure() {
+void test_rebuild_failure_rollback() {
     FilterEngine engine;
     engine.initialize();
-    engine.buildCameraPipeline();
+
+    // 1. Setup a valid initial state
+    auto filter = std::make_shared<ToggledFailureFilter>();
+    engine.addFilterRaw(filter);
+    assert(engine.buildCameraPipeline().isOk());
 
     auto oldGraph = FilterEngineTestAccessor::getGraph(engine);
-    auto oldOutput = FilterEngineTestAccessor::getOutputNode(engine);
     auto oldCamera = FilterEngineTestAccessor::getCameraNode(engine);
+    auto oldOutput = FilterEngineTestAccessor::getOutputNode(engine);
 
-    // To simulate a failure, we need rebuildGraph to fail.
-    // rebuildGraph fails if newGraph->compile() fails.
-    // newGraph->compile() fails if there's a cycle.
-    // rebuildGraph constructs newGraph from existing filters in m_graph.
+    assert(oldGraph != nullptr);
+    assert(oldCamera != nullptr);
 
-    // We can't easily inject a cycle into the rebuild process because it builds a linear chain.
-    // EXCEPT if one of the nodes already has an output that points back to an earlier node.
+    // 2. Trigger a rebuild that will fail
+    filter->shouldFail = true;
+    // Calling buildTimelinePipeline will trigger rebuildGraph
+    Result res = engine.buildTimelinePipeline(nullptr, nullptr);
 
-    if (oldGraph) {
-        auto nodes = oldGraph->getNodes();
-        if (!nodes.empty()) {
-            // Manually create a cycle in one of the existing nodes
-            // This is a bit of a reach but let's see.
-            // Actually, rebuildGraph creates NEW FilterNodes wrapping the same Filters.
-            // FilterNode::addOutput is what creates the connections.
-        }
-    }
+    assert(!res.isOk());
+    assert(res.getErrorCode() == ErrorCode::ERR_GRAPH_NODE_INIT_FAILED);
 
-    // Since I can't easily force a failure in the linear rebuild without modifying the graph nodes themselves,
-    // I will focus on the successful transition for now,
-    // but the code review shows the transactional logic is there.
+    // 3. Verify Rollback: Engine state should be identical to old state
+    assert(FilterEngineTestAccessor::getGraph(engine) == oldGraph);
+    assert(FilterEngineTestAccessor::getCameraNode(engine) == oldCamera);
+    assert(FilterEngineTestAccessor::getOutputNode(engine) == oldOutput);
 
-    std::cout << "test_transactional_rebuild_failure (skipped forced failure, logic verified via code)" << std::endl;
+    std::cout << "test_rebuild_failure_rollback passed" << std::endl;
+}
+
+void test_camera_rebuild_failure_rollback() {
+    FilterEngine engine;
+    engine.initialize();
+
+    // 1. Setup a valid initial state
+    auto filter = std::make_shared<ToggledFailureFilter>();
+    engine.addFilterRaw(filter);
+    assert(engine.buildCameraPipeline().isOk());
+
+    auto oldGraph = FilterEngineTestAccessor::getGraph(engine);
+    auto oldCamera = FilterEngineTestAccessor::getCameraNode(engine);
+    auto oldOutput = FilterEngineTestAccessor::getOutputNode(engine);
+
+    // 2. Trigger a camera rebuild that will fail
+    filter->shouldFail = true;
+    Result res = engine.buildCameraPipeline();
+
+    assert(!res.isOk());
+
+    // 3. Verify Rollback
+    // If buildCameraPipeline is buggy, it might have overwritten m_cameraNode already
+    assert(FilterEngineTestAccessor::getCameraNode(engine) == oldCamera);
+    assert(FilterEngineTestAccessor::getGraph(engine) == oldGraph);
+    assert(FilterEngineTestAccessor::getOutputNode(engine) == oldOutput);
+
+    std::cout << "test_camera_rebuild_failure_rollback passed" << std::endl;
 }
 
 int main() {
-    test_camera_to_timeline_transition();
-    test_transactional_rebuild_failure();
+    test_rebuild_success();
+    test_rebuild_failure_rollback();
+    test_camera_rebuild_failure_rollback();
     return 0;
 }


### PR DESCRIPTION
Hardened FilterEngine's rebuildGraph transactional semantics by adding regression tests and fixing an identified state consistency bug in buildCameraPipeline.

Fixes #142

---
*PR created automatically by Jules for task [229280442560710171](https://jules.google.com/task/229280442560710171) started by @zx2121651*