### PR TITLE
Add local build prerequisites and setup guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,16 @@
 
 ---
 
+## 0. 快速上手 (Getting Started)
+
+对于新开发者或 Agent，请首先查阅 [BUILD.md](./BUILD.md) 以获取完整的**本地构建前置条件说明**。
+
+- **Android**: 确保安装 JDK 17 和 Android SDK/NDK。
+- **iOS**: 需要 macOS 和 Xcode 环境。
+- **Core C++**: 依赖 CMake 3.10.2+。
+
+---
+
 ## 1. 项目概览
 
 本项目采用「**C++ Core + 平台桥接层**」架构：

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,84 @@
+# Local Build Prerequisites & Setup Guide
+
+This document outlines the environment requirements and build instructions for the ShortVideo SDK.
+
+---
+
+## 1. Core C++ Engine (video_sdk_core)
+
+The core engine is cross-platform and uses CMake as the build system.
+
+### Prerequisites (Mandatory)
+- **CMake**: Version 3.10.2 or higher.
+- **C++ Compiler**: Support for C++17 (e.g., GCC 7+, Clang 5+, or MSVC 2017+).
+
+### Optional Dependencies
+- **OpenGL ES 2.0/3.0**: Required for real rendering tests.
+    - **Linux**: `libgles2-mesa-dev`, `libegl1-mesa-dev`.
+    - **Windows**: [ANGLE](https://github.com/google/angle) (can be installed via `vcpkg`).
+- **vcpkg**: Recommended for managing dependencies on Windows.
+
+### Build Commands
+```bash
+cmake -B build -S .
+cmake --build build --config Release
+cd build && ctest
+```
+
+---
+
+## 2. Android SDK & Sample
+
+### Prerequisites (Mandatory)
+- **JDK 17**: Ensure `JAVA_HOME` is set.
+- **Android SDK**: `compileSdk 34`, `minSdk 24`.
+- **Android NDK**: Version 25.1.8937393 (suggested) or matching the CMake configuration.
+- **CMake**: Version 3.22.1 (installed via Android SDK Manager).
+
+### Build Commands
+```bash
+# Build SDK Library
+./gradlew :android:assembleDebug
+
+# Build Sample App
+./gradlew :sample-android:assembleDebug
+
+# Run Unit Tests
+./gradlew :android:testDebugUnitTest
+```
+
+---
+
+## 3. iOS SDK
+
+### Prerequisites (Mandatory)
+- **macOS**: Required for iOS development.
+- **Xcode**: Latest stable version recommended.
+- **Command Line Tools**: `xcodebuild` should be available.
+
+### Build Commands
+```bash
+xcodebuild clean build \
+  -project ios/VideoSDK.xcodeproj \
+  -scheme "VideoSDK" \
+  -destination "generic/platform=iOS Simulator" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+---
+
+## 4. Quick Selection Guide
+
+| Task | Minimum Requirements | Recommended Path |
+| :--- | :--- | :--- |
+| **Logic Verification** | CMake + C++ Compiler | Build `video_sdk_core` with `USE_MOCK_GL=ON` |
+| **Android Dev** | JDK 17 + Android SDK | Use Android Studio or `./gradlew` |
+| **iOS Dev** | macOS + Xcode | Use `ios/VideoSDK.xcodeproj` |
+| **Rendering Tests** | OpenGL ES + EGL | Run `test_headless_ssim` |
+
+---
+
+## 5. Troubleshooting
+- **Windows Build**: If CMake fails to find OpenGL, run `setup_windows_env.ps1` to setup vcpkg and ANGLE.
+- **Gradle Errors**: Ensure `./gradlew` has execution permissions (`chmod +x gradlew`).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 // Module: android (SDK Library)
 // Role: The primary SDK product containing the core video processing logic.
+// Prerequisites: Android SDK 34, Android NDK 25.1.8937393, CMake 3.22.1
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+// Prerequisites: JDK 17, Android SDK 34, Android NDK 25.1.8937393
 plugins {
     id 'com.android.application' version '8.2.1' apply false
     id 'com.android.library' version '8.2.1' apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,4 @@
+# Requires Gradle 8.8. Compatible with JDK 17.
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,13 @@ dependencyResolutionManagement {
 }
 rootProject.name = "ShortVideoSDK"
 
+/**
+ * Project Structure:
+ * - :android -> Core SDK library
+ * - :sample-android -> Integration verification host
+ * For build prerequisites, see BUILD.md in the root directory.
+ */
+
 // SDK Library: The core product of this repository
 include ':android'
 


### PR DESCRIPTION
This PR adds comprehensive documentation for local build prerequisites to lower the onboarding cost for new developers and AI agents. 

Key changes:
1.  **BUILD.md**: A new file in the root directory providing a "source of truth" for environment requirements (JDK 17, Android SDK/NDK, CMake, etc.) and quick-start build commands.
2.  **ARCHITECTURE.md**: Added a "0. Getting Started" section to direct users to the build documentation.
3.  **Build Files**: Injected version requirement comments into `build.gradle`, `android/build.gradle`, `settings.gradle`, and `gradle-wrapper.properties` to provide immediate context when opening these files.

These changes ensure that both human collaborators and AI agents can quickly diagnose environment issues and select the correct verification paths for their tasks.

Fixes #143

---
*PR created automatically by Jules for task [225669837933650145](https://jules.google.com/task/225669837933650145) started by @zx2121651*