### PR TITLE
Tighten FilterEngine initialization idempotency and lifecycle hardening

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,7 +60,7 @@
 #### 2.1.2 FilterEngine（管线总控）
 
 职责：
-1. **初始化**: 绑定渲染线程、触发 `GLContextManager` 能力嗅探。
+1. **初始化**: 绑定渲染线程、触发 `GLContextManager` 能力嗅探。支持幂等调用，但重复调用必须在同一个绑定线程，否则返回错误。
 2. **动态构建**: 根据业务场景（预览/时间线编辑）动态组装 `PipelineGraph`。
    - **事务性重构 (rebuildGraph)**: 采用事务机制，仅在管线成功 `compile()` 后才更新引擎状态（`m_graph`, `m_outputNode` 等），确保失败时不破坏当前运行状态。
 3. **参数广播**: 遍历管线节点，将全局参数（如滤镜强度）下发给对应的 `FilterNode`。
@@ -228,7 +228,7 @@ SDK 错误码采用负值表示，定义在 `core/include/GLTypes.h`。按照 **
 
 ### 6.1 Core C++ 约束
 
-- **线程绑定**: `FilterEngine::initialize()` 被调用时，会通过 `ThreadCheck::bind()` 将当前线程标记为该实例的 Render Thread。
+- **线程绑定**: `FilterEngine::initialize()` 被调用时，会通过 `ThreadCheck::bind()` 将当前线程标记为该实例的 Render Thread。该方法支持幂等性，后续重复调用会校验线程一致性。
 - **调用约束**:
   - `processFrame()`: **必须**在 Render Thread 调用。
   - `addFilter()` / `removeAllFilters()`: **必须**在 Render Thread 调用。

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -17,6 +17,12 @@ FilterEngine::~FilterEngine() {
 
 Result FilterEngine::initialize() {
     if (m_initialized) {
+        // Idempotent Path: Ensure we are still on the same thread that first initialized the engine.
+        // This maintains the "binding" semantics.
+        if (!m_threadCheck.check("Repeated initialize() must be called on the same thread")) {
+            return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine already initialized on another thread");
+        }
+        LOGI("FilterEngine::initialize() - Already initialized, skipping.");
         return Result::ok();
     }
 
@@ -128,6 +134,7 @@ void FilterEngine::release() {
     m_cameraNode = nullptr;
     m_outputNode = nullptr;
     m_isGraphDirty = true;
+    m_renderDevice = nullptr;
 
     m_metricsCollector.clear();
     m_frameBufferPool.clear();

--- a/tests/FilterEngineTestAccessor.h
+++ b/tests/FilterEngineTestAccessor.h
@@ -25,6 +25,10 @@ public:
         return engine.m_metricsCollector;
     }
 
+    static std::shared_ptr<rhi::IRenderDevice> getRenderDevice(const FilterEngine& engine) {
+        return engine.m_renderDevice;
+    }
+
     // Setters used by existing tests
     static void setOutputNode(FilterEngine& engine, std::shared_ptr<OutputNode> node) {
         engine.m_outputNode = node;

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <cassert>
 #include <memory>
+#include <thread>
+#include <future>
 #include "../core/include/FilterEngine.h"
 #include "../core/include/Filters.h"
 #include "FilterEngineTestAccessor.h"
@@ -55,12 +57,33 @@ void test_reinitialize_regression() {
 void test_repeated_init_release() {
     FilterEngine engine;
 
-    std::cout << "Testing repeated initialize..." << std::endl;
-    // 1. Double init
+    std::cout << "Testing repeated initialize on same thread..." << std::endl;
+    // 1. Double init on same thread
     Result res = engine.initialize();
     assert(res.isOk());
+    auto device1 = FilterEngineTestAccessor::getRenderDevice(engine);
+    assert(device1 != nullptr);
+
     res = engine.initialize();
     assert(res.isOk());
+    auto device2 = FilterEngineTestAccessor::getRenderDevice(engine);
+    assert(device1 == device2); // Idempotent: should NOT re-create device
+
+    std::cout << "Testing repeated initialize on different thread..." << std::endl;
+    // 2. Double init on different thread - should FAIL because binding is to first thread
+    std::promise<Result> promise;
+    std::future<Result> future = promise.get_future();
+    std::thread t([&engine, &promise]() {
+        promise.set_value(engine.initialize());
+    });
+    t.join();
+    Result threadRes = future.get();
+    // After my changes, this should fail. Currently it returns OK.
+    // I will update the test to expect FAILURE after I implement the check.
+    // But wait, if I run the test NOW it will fail if I assert it fails.
+    // TDD style: expect failure now.
+    assert(!threadRes.isOk());
+    assert(threadRes.getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
 
     std::cout << "Testing repeated release..." << std::endl;
     // 2. Double release
@@ -71,9 +94,17 @@ void test_repeated_init_release() {
     // 3. Init -> Release -> Init
     res = engine.initialize();
     assert(res.isOk());
+    auto device3 = FilterEngineTestAccessor::getRenderDevice(engine);
+    assert(device3 != nullptr);
+
     engine.release();
+    assert(FilterEngineTestAccessor::getRenderDevice(engine) == nullptr);
+
     res = engine.initialize();
     assert(res.isOk());
+    auto device4 = FilterEngineTestAccessor::getRenderDevice(engine);
+    assert(device4 != nullptr);
+    assert(device3 != device4); // Should be a new device instance
 
     std::cout << "test_repeated_init_release passed" << std::endl;
 }


### PR DESCRIPTION
This change addresses Issue 19 by tightening the idempotent behavior of `FilterEngine::initialize()`. It ensures that repeated calls to `initialize()` are validated against the original binding thread, preventing hidden state differences. It also hardens the `release()` method to ensure a total reset of the rendering state, including the RHI device, facilitating predictable re-initialization cycles.

Fixes #150

---
*PR created automatically by Jules for task [2400660204700928373](https://jules.google.com/task/2400660204700928373) started by @zx2121651*