### PR TITLE
Consolidate FilterEngine::release() and harden public APIs

### DIFF
--- a/core/include/FilterEngine.h
+++ b/core/include/FilterEngine.h
@@ -72,7 +72,7 @@ public:
     Result removeAllFilters();
 
     PerformanceMetrics getPerformanceMetrics() const { return m_metricsCollector.getMetrics(); }
-    void recordDroppedFrame() { m_metricsCollector.recordDroppedFrame(); }
+    void recordDroppedFrame() { if (m_initialized) m_metricsCollector.recordDroppedFrame(); }
     Result updateShaderSource(const std::string& name, const std::string& source);
 
 

--- a/core/include/ThreadCheck.h
+++ b/core/include/ThreadCheck.h
@@ -10,6 +10,7 @@ public:
     ThreadCheck();
 
     void bind();
+    void unbind();
     bool check(const std::string& msg = "Called on incorrect thread") const;
 
 private:

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -100,6 +100,7 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
 }
 
 void FilterEngine::updateParameter(const std::string& key, const std::any& value) {
+    if (!m_initialized) return;
     if (m_graph) {
         for (const auto& node : m_graph->getNodes()) {
             auto filterNode = std::dynamic_pointer_cast<FilterNode>(node);
@@ -111,6 +112,7 @@ void FilterEngine::updateParameter(const std::string& key, const std::any& value
 }
 
 void FilterEngine::updateParameterMat4(const std::string& key, const float* matrix) {
+    if (!m_initialized) return;
     if (m_graph) {
         for (const auto& node : m_graph->getNodes()) {
             auto filterNode = std::dynamic_pointer_cast<FilterNode>(node);
@@ -126,23 +128,35 @@ void FilterEngine::release() {
         return;
     }
 
+    // 1. Graph release and reset
     if (m_graph) {
         m_graph->release();
-        m_graph.reset();
+        m_graph = nullptr;
     }
 
+    // 2. Node reference nullification
     m_cameraNode = nullptr;
     m_outputNode = nullptr;
-    m_isGraphDirty = true;
+
+    // 3. RHI device nullification
     m_renderDevice = nullptr;
 
-    m_metricsCollector.clear();
+    // 4. FrameBufferPool and MetricsCollector clearing
     m_frameBufferPool.clear();
+    m_metricsCollector.clear();
 
+    // 5. State flags reset
+    m_isGraphDirty = true;
     m_initialized = false;
+
+    // 6. ThreadCheck unbinding
+    m_threadCheck.unbind();
 }
 
 Result FilterEngine::addFilterRaw(FilterPtr filter) {
+    if (!m_initialized) {
+        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+    }
     if (filter) {
         filter->setShaderManager(m_shaderManager);
         if (!m_graph) { m_graph = std::make_shared<PipelineGraph>(); }
@@ -158,6 +172,13 @@ Result FilterEngine::addFilterRaw(FilterPtr filter) {
     return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Filter is null");
 }
 Result FilterEngine::addFilter(FilterType type) {
+    if (!m_initialized) {
+        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+    }
+    // We must have a render device to create filters
+    if (!m_renderDevice) {
+        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Render device is null");
+    }
     FilterPtr filter = FilterFactory::createFilter(type, m_contextManager, &m_frameBufferPool, m_renderDevice);
     if (filter) {
         return addFilterRaw(filter);
@@ -166,6 +187,9 @@ Result FilterEngine::addFilter(FilterType type) {
 }
 
 Result FilterEngine::removeAllFilters() {
+    if (!m_initialized) {
+        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+    }
     if (m_graph) {
         m_graph->release();
         m_graph = std::make_shared<PipelineGraph>();
@@ -177,6 +201,9 @@ Result FilterEngine::removeAllFilters() {
 
 
 Result FilterEngine::updateShaderSource(const std::string& name, const std::string& source) {
+    if (!m_initialized) {
+        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+    }
     if (!m_shaderManager) return Result::error("ShaderManager is null");
 
     m_shaderManager->updateShaderSource(name, source);
@@ -197,11 +224,17 @@ Result FilterEngine::updateShaderSource(const std::string& name, const std::stri
 }
 
 Result FilterEngine::buildCameraPipeline() {
+    if (!m_initialized) {
+        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+    }
     auto cameraNode = std::make_shared<CameraInputNode>("Camera");
     return rebuildGraph(cameraNode);
 }
 
 Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> timeline, std::shared_ptr<timeline::Compositor> compositor) {
+    if (!m_initialized) {
+        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+    }
     auto timelineNode = std::make_shared<TimelineNode>("Timeline", timeline, compositor);
     return rebuildGraph(timelineNode);
 }

--- a/core/src/ThreadCheck.cpp
+++ b/core/src/ThreadCheck.cpp
@@ -11,6 +11,10 @@ void ThreadCheck::bind() {
     m_bound = true;
 }
 
+void ThreadCheck::unbind() {
+    m_bound = false;
+}
+
 bool ThreadCheck::check(const std::string& msg) const {
     if (!m_bound) {
         std::cerr << "ThreadCheck Error: Not bound yet! " << msg << std::endl;

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -144,9 +144,28 @@ void test_lifecycle_functionality() {
     std::cout << "test_lifecycle_functionality passed" << std::endl;
 }
 
+void test_post_release_api_behavior() {
+    FilterEngine engine;
+    engine.initialize();
+    engine.release();
+
+    std::cout << "Testing API behavior after release..." << std::endl;
+
+    assert(engine.addFilter(FilterType::BRIGHTNESS).getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+    assert(engine.removeAllFilters().getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+    assert(engine.buildCameraPipeline().getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+    assert(engine.updateShaderSource("test", "void main() {}").getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+
+    Texture tex{1, 1920, 1080};
+    assert(engine.processFrame(tex, 1920, 1080).getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+
+    std::cout << "test_post_release_api_behavior passed" << std::endl;
+}
+
 int main() {
     test_reinitialize_regression();
     test_repeated_init_release();
     test_lifecycle_functionality();
+    test_post_release_api_behavior();
     return 0;
 }


### PR DESCRIPTION
This change consolidates the `FilterEngine::release()` resource cleanup sequence to ensure consistent state after release. It also hardens the `FilterEngine` public APIs by adding initialization checks, ensuring they return `ERR_RENDER_INVALID_STATE` instead of potentially crashing after the engine has been released. Additionally, it updates the `ThreadCheck` utility to support unbinding, enabling safe re-initialization on new threads. Verification was performed via the expanded `test_lifecycle` suite and all existing core C++ tests.

Fixes #151

---
*PR created automatically by Jules for task [8904898638704661095](https://jules.google.com/task/8904898638704661095) started by @zx2121651*