### PR TITLE
Core: Tighten FilterEngine::processFrame thread violation semantics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -196,7 +196,7 @@ SDK 错误码采用负值表示，定义在 `core/include/GLTypes.h`。按照 **
 | 模块 | 错误范围 | 核心职责 | 典型错误示例 |
 | :--- | :--- | :--- | :--- |
 | **Initialization** | -1000 ~ -1999 | 基础环境搭建、硬件能力嗅探。 | `ERR_INIT_CONTEXT_FAILED`: GPU 上下文无法创建。 |
-| **Rendering** | -2000 ~ -2999 | 滤镜执行、FBO 管理、RHI 交互。 | `ERR_RENDER_INVALID_STATE`: 跨线程调用渲染 API。 |
+| **Rendering** | -2000 ~ -2999 | 滤镜执行、FBO 管理、RHI 交互。 | `ERR_RENDER_THREAD_VIOLATION`: 跨线程调用渲染 API。 |
 | **Timeline/Decoder** | -3000 ~ -3999 | 视频解码、多轨合成、时间轴逻辑。 | `ERR_DECODER_SEEK_FAILED`: 硬解定位失败，触发软解。 |
 | **Graph** | -4000 ~ -4999 | 渲染图拓扑校验、编译。 | `ERR_GRAPH_CYCLE_DETECTED`: 滤镜连接形成死循环。 |
 | **Exporter** | -5000 ~ -5999 | 离线录制、封装、编码。 | `ERR_EXPORTER_IO_ERROR`: 磁盘空间不足或无写入权限。 |
@@ -218,7 +218,7 @@ SDK 错误码采用负值表示，定义在 `core/include/GLTypes.h`。按照 **
 
 3. **典型场景触发流程**:
    - **FBO 耗尽**: `ERR_RENDER_FBO_ALLOC_FAILED` (-2001) -> 自动清理 LRU 缓存 -> 若仍失败，则 Bypass 滤镜并记录埋点。
-   - **跨线程错误**: `ERR_RENDER_INVALID_STATE` (-2002) -> 触发断言或抛出 Java/Swift 异常，警示开发者调用逻辑错误。
+   - **跨线程错误**: `ERR_RENDER_THREAD_VIOLATION` (-2004) -> 触发断言或抛出 Java/Swift 异常，警示开发者调用逻辑错误。
 
 ---
 
@@ -233,7 +233,7 @@ SDK 错误码采用负值表示，定义在 `core/include/GLTypes.h`。按照 **
   - `processFrame()`: **必须**在 Render Thread 调用。
   - `addFilter()` / `removeAllFilters()`: **必须**在 Render Thread 调用。
   - `release()`: **必须**在 Render Thread 调用，以确保显存资源同步释放。
-- **防御机制**: 核心 API 内部集成了 `ThreadCheck`。若发生跨线程调用，API 将返回 `ERR_RENDER_INVALID_STATE` (-2002)，并在 `stderr` 打印：`ThreadCheck Error: processFrame must be called on the render thread`。
+- **防御机制**: 核心 API 内部集成了 `ThreadCheck`。若发生跨线程调用，API 将返回 `ERR_RENDER_THREAD_VIOLATION` (-2004)，并在日志中输出带 `[ThreadViolation]` 前缀的错误信息。
 
 ### 6.2 Android 平台适配 (Facade)
 

--- a/core/include/GLTypes.h
+++ b/core/include/GLTypes.h
@@ -48,6 +48,7 @@ enum ErrorCode {
     ERR_RENDER_FBO_ALLOC_FAILED = -2001,       // 显存不足，无法分配帧缓冲
     ERR_RENDER_INVALID_STATE = -2002,          // 状态异常（如在非渲染线程调用，或管线未编译）
     ERR_RENDER_COMPUTE_NOT_SUPPORTED = -2003,  // 当前硬件不支持 Compute Shader
+    ERR_RENDER_THREAD_VIOLATION = -2004,       // 线程违规（在非绑定渲染线程调用渲染 API）
 
     // --- [Category: Timeline & Decoder] (Recoverable) Range: -3000 ~ -3999 ---
     // 编辑、解码相关错误，建议触发重试或软解回退

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -20,7 +20,7 @@ Result FilterEngine::initialize() {
         // Idempotent Path: Ensure we are still on the same thread that first initialized the engine.
         // This maintains the "binding" semantics.
         if (!m_threadCheck.check("Repeated initialize() must be called on the same thread")) {
-            return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine already initialized on another thread");
+            return Result::error(ErrorCode::ERR_RENDER_THREAD_VIOLATION, "FilterEngine already initialized on another thread");
         }
         LOGI("FilterEngine::initialize() - Already initialized, skipping.");
         return Result::ok();
@@ -53,7 +53,7 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
 
     // Thread Safety: Verify that we are still on the Render Thread.
     if (!m_threadCheck.check("processFrame must be called on the render thread")) {
-        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "GL Thread violation detected during processFrame");
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_THREAD_VIOLATION, "GL Thread violation detected during processFrame");
     }
 
     auto start_time = std::chrono::high_resolution_clock::now();

--- a/core/src/ThreadCheck.cpp
+++ b/core/src/ThreadCheck.cpp
@@ -1,5 +1,6 @@
 #include "../include/ThreadCheck.h"
-#include <iostream>
+#define LOG_TAG "ThreadCheck"
+#include "../include/Log.h"
 
 namespace sdk {
 namespace video {
@@ -17,11 +18,11 @@ void ThreadCheck::unbind() {
 
 bool ThreadCheck::check(const std::string& msg) const {
     if (!m_bound) {
-        std::cerr << "ThreadCheck Error: Not bound yet! " << msg << std::endl;
+        LOGE("[ThreadViolation] Not bound yet! %s", msg.c_str());
         return false;
     }
     if (std::this_thread::get_id() != m_threadId) {
-        std::cerr << "ThreadCheck Error: " << msg << std::endl;
+        LOGE("[ThreadViolation] %s", msg.c_str());
         return false;
     }
     return true;

--- a/tests/test_filter_graph.cpp
+++ b/tests/test_filter_graph.cpp
@@ -84,7 +84,7 @@ void test_filter_engine_thread_violation() {
     t.join();
 
     assert(!res.isOk());
-    assert(res.getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+    assert(res.getErrorCode() == ErrorCode::ERR_RENDER_THREAD_VIOLATION);
     assert(res.getMessage().find("Thread violation") != std::string::npos);
 
     std::cout << "test_filter_engine_thread_violation passed" << std::endl;

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -78,12 +78,9 @@ void test_repeated_init_release() {
     });
     t.join();
     Result threadRes = future.get();
-    // After my changes, this should fail. Currently it returns OK.
-    // I will update the test to expect FAILURE after I implement the check.
-    // But wait, if I run the test NOW it will fail if I assert it fails.
-    // TDD style: expect failure now.
+    // Expect failure with specific thread violation code
     assert(!threadRes.isOk());
-    assert(threadRes.getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+    assert(threadRes.getErrorCode() == ErrorCode::ERR_RENDER_THREAD_VIOLATION);
 
     std::cout << "Testing repeated release..." << std::endl;
     // 2. Double release
@@ -144,6 +141,26 @@ void test_lifecycle_functionality() {
     std::cout << "test_lifecycle_functionality passed" << std::endl;
 }
 
+void test_process_frame_thread_violation() {
+    FilterEngine engine;
+    engine.initialize();
+
+    std::cout << "Testing processFrame thread violation..." << std::endl;
+    Texture tex{1, 1920, 1080};
+
+    std::promise<ResultPayload<Texture>> promise;
+    std::future<ResultPayload<Texture>> future = promise.get_future();
+    std::thread t([&engine, &promise, tex]() {
+        promise.set_value(engine.processFrame(tex, 1920, 1080));
+    });
+    t.join();
+
+    auto res = future.get();
+    assert(!res.isOk());
+    assert(res.getErrorCode() == ErrorCode::ERR_RENDER_THREAD_VIOLATION);
+    std::cout << "test_process_frame_thread_violation passed" << std::endl;
+}
+
 void test_post_release_api_behavior() {
     FilterEngine engine;
     engine.initialize();
@@ -165,6 +182,7 @@ void test_post_release_api_behavior() {
 int main() {
     test_reinitialize_regression();
     test_repeated_init_release();
+    test_process_frame_thread_violation();
     test_lifecycle_functionality();
     test_post_release_api_behavior();
     return 0;


### PR DESCRIPTION
This change standardizes thread violation handling in FilterEngine. It introduces a specific error code, improves logging for better diagnosability, and adds regression tests to ensure stable failure semantics on both processFrame and initialize paths.

Fixes #247

---
*PR created automatically by Jules for task [4056129910774370526](https://jules.google.com/task/4056129910774370526) started by @zx2121651*