### PR TITLE
[Core] Enforce FilterEngine initialization contract

### DIFF
--- a/core/include/GLTypes.h
+++ b/core/include/GLTypes.h
@@ -49,6 +49,7 @@ enum ErrorCode {
     ERR_RENDER_INVALID_STATE = -2002,          // 状态异常（如在非渲染线程调用，或管线未编译）
     ERR_RENDER_COMPUTE_NOT_SUPPORTED = -2003,  // 当前硬件不支持 Compute Shader
     ERR_RENDER_THREAD_VIOLATION = -2004,       // 线程违规（在非绑定渲染线程调用渲染 API）
+    ERR_RENDER_NOT_INITIALIZED = -2005,        // 引擎未初始化（调用 processFrame 前必须先调用 initialize）
 
     // --- [Category: Timeline & Decoder] (Recoverable) Range: -3000 ~ -3999 ---
     // 编辑、解码相关错误，建议触发重试或软解回退

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -48,7 +48,8 @@ Result FilterEngine::initialize() {
 
 ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int width, int height) {
     if (!m_initialized) {
-        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized before processing frame");
+        LOGE("processFrame() called before initialize(). Did you forget to call initialize()?");
+        return ResultPayload<Texture>::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized before processing frame");
     }
 
     // Thread Safety: Verify that we are still on the Render Thread.
@@ -155,7 +156,8 @@ void FilterEngine::release() {
 
 Result FilterEngine::addFilterRaw(FilterPtr filter) {
     if (!m_initialized) {
-        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+        LOGE("addFilterRaw() called before initialize()");
+        return Result::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized");
     }
     if (filter) {
         filter->setShaderManager(m_shaderManager);
@@ -173,7 +175,8 @@ Result FilterEngine::addFilterRaw(FilterPtr filter) {
 }
 Result FilterEngine::addFilter(FilterType type) {
     if (!m_initialized) {
-        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+        LOGE("addFilter() called before initialize()");
+        return Result::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized");
     }
     // We must have a render device to create filters
     if (!m_renderDevice) {
@@ -188,7 +191,8 @@ Result FilterEngine::addFilter(FilterType type) {
 
 Result FilterEngine::removeAllFilters() {
     if (!m_initialized) {
-        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+        LOGE("removeAllFilters() called before initialize()");
+        return Result::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized");
     }
     if (m_graph) {
         m_graph->release();
@@ -202,7 +206,8 @@ Result FilterEngine::removeAllFilters() {
 
 Result FilterEngine::updateShaderSource(const std::string& name, const std::string& source) {
     if (!m_initialized) {
-        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+        LOGE("updateShaderSource() called before initialize()");
+        return Result::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized");
     }
     if (!m_shaderManager) return Result::error("ShaderManager is null");
 
@@ -225,7 +230,8 @@ Result FilterEngine::updateShaderSource(const std::string& name, const std::stri
 
 Result FilterEngine::buildCameraPipeline() {
     if (!m_initialized) {
-        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+        LOGE("buildCameraPipeline() called before initialize()");
+        return Result::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized");
     }
     auto cameraNode = std::make_shared<CameraInputNode>("Camera");
     return rebuildGraph(cameraNode);
@@ -233,7 +239,8 @@ Result FilterEngine::buildCameraPipeline() {
 
 Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> timeline, std::shared_ptr<timeline::Compositor> compositor) {
     if (!m_initialized) {
-        return Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterEngine not initialized");
+        LOGE("buildTimelinePipeline() called before initialize()");
+        return Result::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized");
     }
     auto timelineNode = std::make_shared<TimelineNode>("Timeline", timeline, compositor);
     return rebuildGraph(timelineNode);

--- a/tests/test_filter_graph.cpp
+++ b/tests/test_filter_graph.cpp
@@ -66,7 +66,7 @@ void test_filter_engine_uninitialized() {
     Texture inTex{1, 100, 100};
     auto res = engine.processFrame(inTex, 100, 100);
     assert(!res.isOk());
-    assert(res.getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+    assert(res.getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
     assert(res.getMessage().find("not initialized") != std::string::npos);
 
     std::cout << "test_filter_engine_uninitialized passed" << std::endl;

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -161,6 +161,25 @@ void test_process_frame_thread_violation() {
     std::cout << "test_process_frame_thread_violation passed" << std::endl;
 }
 
+void test_uninitialized_call_order() {
+    FilterEngine engine;
+
+    std::cout << "Testing API behavior before first initialization..." << std::endl;
+
+    // These should all fail with ERR_RENDER_NOT_INITIALIZED
+    assert(engine.addFilter(FilterType::BRIGHTNESS).getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
+    assert(engine.removeAllFilters().getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
+    assert(engine.buildCameraPipeline().getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
+    assert(engine.updateShaderSource("test", "void main() {}").getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
+
+    Texture tex{1, 1920, 1080};
+    auto res = engine.processFrame(tex, 1920, 1080);
+    assert(res.getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
+    assert(res.getMessage().find("not initialized") != std::string::npos);
+
+    std::cout << "test_uninitialized_call_order passed" << std::endl;
+}
+
 void test_post_release_api_behavior() {
     FilterEngine engine;
     engine.initialize();
@@ -168,18 +187,19 @@ void test_post_release_api_behavior() {
 
     std::cout << "Testing API behavior after release..." << std::endl;
 
-    assert(engine.addFilter(FilterType::BRIGHTNESS).getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
-    assert(engine.removeAllFilters().getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
-    assert(engine.buildCameraPipeline().getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
-    assert(engine.updateShaderSource("test", "void main() {}").getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+    assert(engine.addFilter(FilterType::BRIGHTNESS).getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
+    assert(engine.removeAllFilters().getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
+    assert(engine.buildCameraPipeline().getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
+    assert(engine.updateShaderSource("test", "void main() {}").getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
 
     Texture tex{1, 1920, 1080};
-    assert(engine.processFrame(tex, 1920, 1080).getErrorCode() == ErrorCode::ERR_RENDER_INVALID_STATE);
+    assert(engine.processFrame(tex, 1920, 1080).getErrorCode() == ErrorCode::ERR_RENDER_NOT_INITIALIZED);
 
     std::cout << "test_post_release_api_behavior passed" << std::endl;
 }
 
 int main() {
+    test_uninitialized_call_order();
     test_reinitialize_regression();
     test_repeated_init_release();
     test_process_frame_thread_violation();


### PR DESCRIPTION
This change establishes a strict "uninitialized = no rendering logic" contract in the FilterEngine. It introduces a specific error code ERR_RENDER_NOT_INITIALIZED (-2005) and updates all relevant public APIs (processFrame, addFilter, buildCameraPipeline, etc.) to check for initialization and log descriptive error messages on violation. Lifecycle tests have been strengthened to ensure this contract holds before initialization and after release.

Fixes #248

---
*PR created automatically by Jules for task [12543683214374309554](https://jules.google.com/task/12543683214374309554) started by @zx2121651*