### PR TITLE
[Core] Refine FilterEngine graph auto-rebuild logic to respect active mode

### DIFF
--- a/core/include/FilterEngine.h
+++ b/core/include/FilterEngine.h
@@ -85,6 +85,12 @@ public:
     // Test access
     friend class FilterEngineTestAccessor;
 
+    enum class PipelineMode {
+        UNDEFINED,
+        CAMERA,
+        TIMELINE
+    };
+
 private:
     FrameBufferPool m_frameBufferPool;
     std::shared_ptr<ShaderManager> m_shaderManager;
@@ -98,6 +104,10 @@ private:
     ThreadCheck m_threadCheck;
     bool m_initialized;
     mutable MetricsCollector m_metricsCollector;
+
+    PipelineMode m_currentMode = PipelineMode::UNDEFINED;
+    std::shared_ptr<timeline::Timeline> m_timeline;
+    std::weak_ptr<timeline::Compositor> m_compositor;
 
 
     // 【三级防线】特征级嗅探器

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -60,9 +60,24 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
     auto start_time = std::chrono::high_resolution_clock::now();
 
     if (m_isGraphDirty) {
-        Result res = buildCameraPipeline();
+        Result res = Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Pipeline not configured");
+        if (m_currentMode == PipelineMode::CAMERA) {
+            LOGI("Auto-rebuilding Camera pipeline...");
+            res = buildCameraPipeline();
+        } else if (m_currentMode == PipelineMode::TIMELINE) {
+            LOGI("Auto-rebuilding Timeline pipeline...");
+            if (auto compositor = m_compositor.lock()) {
+                auto timelineNode = std::make_shared<TimelineNode>("Timeline", m_timeline, compositor);
+                res = rebuildGraph(timelineNode);
+            } else {
+                res = Result::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Compositor already released");
+            }
+        } else {
+            LOGE("processFrame() failed: No pipeline mode established. Call buildCameraPipeline() or buildTimelinePipeline() first.");
+        }
+
         if (!res.isOk()) {
-            return ResultPayload<Texture>::error(res.getErrorCode(), "Pipeline build failed: " + res.getMessage());
+            return ResultPayload<Texture>::error(res.getErrorCode(), "Pipeline auto-rebuild failed: " + res.getMessage());
         }
         m_isGraphDirty = false;
     }
@@ -149,6 +164,9 @@ void FilterEngine::release() {
     // 5. State flags reset
     m_isGraphDirty = true;
     m_initialized = false;
+    m_currentMode = PipelineMode::UNDEFINED;
+    m_timeline = nullptr;
+    m_compositor.reset();
 
     // 6. ThreadCheck unbinding
     m_threadCheck.unbind();
@@ -234,7 +252,13 @@ Result FilterEngine::buildCameraPipeline() {
         return Result::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized");
     }
     auto cameraNode = std::make_shared<CameraInputNode>("Camera");
-    return rebuildGraph(cameraNode);
+    Result res = rebuildGraph(cameraNode);
+    if (res.isOk()) {
+        m_currentMode = PipelineMode::CAMERA;
+        m_timeline = nullptr;
+        m_compositor.reset();
+    }
+    return res;
 }
 
 Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> timeline, std::shared_ptr<timeline::Compositor> compositor) {
@@ -243,7 +267,13 @@ Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> t
         return Result::error(ErrorCode::ERR_RENDER_NOT_INITIALIZED, "FilterEngine not initialized");
     }
     auto timelineNode = std::make_shared<TimelineNode>("Timeline", timeline, compositor);
-    return rebuildGraph(timelineNode);
+    Result res = rebuildGraph(timelineNode);
+    if (res.isOk()) {
+        m_currentMode = PipelineMode::TIMELINE;
+        m_timeline = timeline;
+        m_compositor = compositor;
+    }
+    return res;
 }
 
 Result FilterEngine::rebuildGraph(std::shared_ptr<PipelineNode> inputNode) {

--- a/tests/test_filter_graph.cpp
+++ b/tests/test_filter_graph.cpp
@@ -41,6 +41,8 @@ public:
 
 void test_filter_graph_creation() {
     FilterEngine engine;
+    engine.initialize();
+    engine.buildCameraPipeline();
 
     // Add multiple filters
     engine.addFilter(FilterType::BRIGHTNESS);
@@ -93,9 +95,10 @@ void test_filter_engine_thread_violation() {
 void test_filter_engine_build_failure() {
     FilterEngine engine;
     engine.initialize();
+    engine.buildCameraPipeline();
 
     // addFilterRaw doesn't trigger rebuildGraph immediately, it sets m_isGraphDirty = true.
-    // The next processFrame will call buildCameraPipeline() -> rebuildGraph().
+    // The next processFrame will call auto-rebuild.
     auto failureFilter = std::make_shared<FailureFilter>();
     engine.addFilterRaw(failureFilter);
 


### PR DESCRIPTION
This change introduces an explicit PipelineMode to FilterEngine to ensure that automatic graph reconstruction in processFrame() correctly respects the currently active pipeline (CAMERA or TIMELINE) instead of defaulting to camera. This prevents implicit mode switching and makes the engine state more predictable.

Fixes #249

---
*PR created automatically by Jules for task [16074134540968300629](https://jules.google.com/task/16074134540968300629) started by @zx2121651*