### PR TITLE
Fix FilterEngine::processFrame error propagation and logging

### DIFF
--- a/core/include/pipeline/Nodes.h
+++ b/core/include/pipeline/Nodes.h
@@ -51,19 +51,21 @@ public:
 
     ResultPayload<VideoFrame> pullFrame(int64_t timestampNs) override {
         if (m_inputs.empty()) {
-            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterNode has no input");
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "[Node: " + m_name + "] FilterNode has no input");
         }
         if (!m_filter) {
-            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "FilterNode has no filter");
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "[Node: " + m_name + "] FilterNode has no filter");
         }
 
         // Pull from upstream
         auto upstreamRes = m_inputs[0]->pullFrame(timestampNs);
-        if (!upstreamRes.isOk()) return upstreamRes;
+        if (!upstreamRes.isOk()) {
+            return ResultPayload<VideoFrame>::error(upstreamRes.getErrorCode(), "[Node: " + m_name + "] <- " + upstreamRes.getMessage());
+        }
 
         VideoFrame upstreamFrame = upstreamRes.getValue();
         if (!upstreamFrame.isValid()) {
-            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "Upstream produced an invalid frame");
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "[Node: " + m_name + "] Upstream produced an invalid frame");
         }
 
         Texture texIn{upstreamFrame.textureId, upstreamFrame.width, upstreamFrame.height};
@@ -76,7 +78,7 @@ public:
 
         auto processRes = m_filter->processFrame(texIn, fbo);
         if (!processRes.isOk()) {
-            return ResultPayload<VideoFrame>::error(processRes.getErrorCode(), processRes.getMessage());
+            return ResultPayload<VideoFrame>::error(processRes.getErrorCode(), "[Node: " + m_name + "] " + processRes.getMessage());
         }
         Texture texOut = processRes.getValue();
 
@@ -108,12 +110,14 @@ public:
 
     ResultPayload<VideoFrame> pullFrame(int64_t timestampNs) override {
         if (m_inputs.empty()) {
-            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "OutputNode has no input");
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "[Node: " + m_name + "] OutputNode has no input");
         }
 
         auto res = m_inputs[0]->pullFrame(timestampNs);
         if (res.isOk()) {
             m_lastFrame = res.getValue();
+        } else {
+            return ResultPayload<VideoFrame>::error(res.getErrorCode(), "[Node: " + m_name + "] <- " + res.getMessage());
         }
         return res;
     }

--- a/core/include/pipeline/TimelineNode.h
+++ b/core/include/pipeline/TimelineNode.h
@@ -16,7 +16,7 @@ public:
 
     ResultPayload<VideoFrame> pullFrame(int64_t timestampNs) override {
         if (!m_timeline || !m_compositor) {
-            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "TimelineNode not properly initialized");
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_INVALID_STATE, "[Node: " + m_name + "] TimelineNode not properly initialized");
         }
 
         // Convert ns to ms or internal timeline units
@@ -37,12 +37,12 @@ public:
         }
 
         if (!fbo) {
-            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED, "Failed to allocate FBO for TimelineNode");
+            return ResultPayload<VideoFrame>::error(ErrorCode::ERR_RENDER_FBO_ALLOC_FAILED, "[Node: " + m_name + "] Failed to allocate FBO for TimelineNode");
         }
 
         Result res = m_compositor->renderFrameAtTime(timeNs, fbo);
         if (!res.isOk()) {
-            return ResultPayload<VideoFrame>::error(res.getErrorCode(), res.getMessage());
+            return ResultPayload<VideoFrame>::error(res.getErrorCode(), "[Node: " + m_name + "] " + res.getMessage());
         }
 
         VideoFrame frame;

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -95,7 +95,7 @@ ResultPayload<Texture> FilterEngine::processFrame(const Texture& textureIn, int 
 
         Result execRes = m_graph->execute(0);
         if (!execRes.isOk()) {
-            LOGE("Graph execution failed: %s", execRes.getMessage().c_str());
+            LOGE("Graph execution failed [Error: %d]: %s", execRes.getErrorCode(), execRes.getMessage().c_str());
             return ResultPayload<Texture>::error(execRes.getErrorCode(), execRes.getMessage());
         }
 

--- a/core/src/pipeline/PipelineGraph.cpp
+++ b/core/src/pipeline/PipelineGraph.cpp
@@ -1,5 +1,7 @@
 #include <algorithm>
 #include "../../include/pipeline/PipelineGraph.h"
+#define LOG_TAG "PipelineGraph"
+#include "../../include/Log.h"
 #include <iostream>
 
 namespace sdk {
@@ -107,6 +109,7 @@ Result PipelineGraph::execute(int64_t timestampNs) {
     for (auto* sink : m_sinkNodes) {
         auto res = sink->pullFrame(timestampNs);
         if (!res.isOk()) {
+            LOGE("Execution failed at sink node '%s': %s", sink->getName().c_str(), res.getMessage().c_str());
             return Result::error(res.getErrorCode(), res.getMessage());
         }
     }

--- a/tests/FilterEngineTestAccessor.h
+++ b/tests/FilterEngineTestAccessor.h
@@ -39,6 +39,9 @@ public:
     static void setGraphDirty(FilterEngine& engine, bool dirty) {
         engine.m_isGraphDirty = dirty;
     }
+    static void setGraph(FilterEngine& engine, std::shared_ptr<PipelineGraph> graph) {
+        engine.m_graph = graph;
+    }
 };
 
 } // namespace video

--- a/tests/test_filter_graph.cpp
+++ b/tests/test_filter_graph.cpp
@@ -231,9 +231,53 @@ void test_graph_execute_pull_failure() {
     Result execRes = graph.execute(1000);
     assert(!execRes.isOk());
     assert(execRes.getErrorCode() == ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED);
+    // Updated expectation: PipelineGraph::execute returns the error from the sink
+    // and also logs it. The message should now contain the node info if wrapped.
+    // Actually, MockPullFailureNode here is a sink (no outputs).
+    // Sink Node directly returns its pullFrame result.
     assert(execRes.getMessage() == "Mock pull failure");
 
     std::cout << "test_graph_execute_pull_failure passed" << std::endl;
+}
+
+void test_filter_engine_execute_failure_transparency() {
+    FilterEngine engine;
+    engine.initialize();
+    engine.buildCameraPipeline();
+
+    // Inject a failure node into the graph as the input to the output node
+    auto failureNode = std::make_shared<MockPullFailureNode>("InternalFailureNode");
+    auto outputNode = std::make_shared<OutputNode>("DisplaySink");
+
+    auto graph = std::make_shared<PipelineGraph>();
+    graph->addNode(failureNode);
+    graph->addNode(outputNode);
+    graph->connect(failureNode, outputNode);
+    assert(graph->compile().isOk());
+
+    FilterEngineTestAccessor::setGraph(engine, graph);
+    FilterEngineTestAccessor::setOutputNode(engine, outputNode);
+    FilterEngineTestAccessor::setGraphDirty(engine, false);
+
+    Texture inTex{1, 100, 100};
+    auto res = engine.processFrame(inTex, 100, 100);
+
+    assert(!res.isOk());
+    assert(res.getErrorCode() == ErrorCode::ERR_TIMELINE_DECODER_GET_FRAME_FAILED);
+
+    // Message should have the chain: [Node: DisplaySink] <- [Node: InternalFailureNode] <- Mock pull failure
+    // Wait, let's trace:
+    // OutputNode::pullFrame calls m_inputs[0]->pullFrame (InternalFailureNode)
+    // InternalFailureNode::pullFrame returns "Mock pull failure"
+    // OutputNode::pullFrame returns "[Node: DisplaySink] <- Mock pull failure"
+    // FilterEngine returns that message.
+
+    // Update: InternalFailureNode is MockPullFailureNode which does NOT wrap message.
+    // So OutputNode wraps it once.
+    std::string expectedMsg = "[Node: DisplaySink] <- Mock pull failure";
+    assert(res.getMessage() == expectedMsg);
+
+    std::cout << "test_filter_engine_execute_failure_transparency passed" << std::endl;
 }
 
 void test_graph_compile_idempotency() {
@@ -313,6 +357,7 @@ int main() {
     test_graph_node_init_failure();
     test_graph_no_sink_nodes();
     test_graph_execute_pull_failure();
+    test_filter_engine_execute_failure_transparency();
     test_graph_compile_idempotency();
     return 0;
 }


### PR DESCRIPTION
This change ensures that graph execution failures in FilterEngine::processFrame are transparently propagated to the caller with descriptive context.

Key improvements:
- Modified FilterNode, OutputNode, and TimelineNode to include node names in error messages during pullFrame.
- Implemented a "<-" chain in error messages to trace nested failures through the graph.
- Enhanced PipelineGraph::execute to log the specific sink node that failed.
- Updated FilterEngine::processFrame to include the numeric error code in the failure log.
- Added a regression test test_filter_engine_execute_failure_transparency in test_filter_graph.cpp to verify the propagation chain.

These changes prevent silent fallbacks and improve diagnostic capabilities for platform-level SDK integrations.

Fixes #250

---
*PR created automatically by Jules for task [2380089693526059021](https://jules.google.com/task/2380089693526059021) started by @zx2121651*