### PR TITLE
FaceLandmarkDetector: complete decodeLandmarks post-processing

### DIFF
--- a/core/include/ai/FaceLandmarkDetector.h
+++ b/core/include/ai/FaceLandmarkDetector.h
@@ -44,8 +44,8 @@ static constexpr int kFaceLandmarkCount = 106;
 static constexpr int kMaxFaces          = 2;
 
 struct FaceLandmark {
-    float x = 0.f;  ///< 归一化横坐标 [0,1]
-    float y = 0.f;  ///< 归一化纵坐标 [0,1]
+    float x = 0.f;  ///< 像素横坐标 (denormalized: x * width)
+    float y = 0.f;  ///< 像素纵坐标 (denormalized: y * height)
     float score = 0.f; ///< 置信度 [0,1]
 };
 

--- a/core/src/ai/FaceLandmarkDetector.cpp
+++ b/core/src/ai/FaceLandmarkDetector.cpp
@@ -381,29 +381,57 @@ void FaceLandmarkDetector::decodeLandmarks(const float* out, int outLen,
         return;
     }
 
+    int numValidPoints = 0;
+    float minX = 1.0f, minY = 1.0f, maxX = 0.0f, maxY = 0.0f;
+
     if (outLen == kFaceLandmarkCount * 2) {
         for (int i = 0; i < kFaceLandmarkCount; ++i) {
-            face.landmarks[i].x     = out[i * 2 + 0] * (float)imgW;
-            face.landmarks[i].y     = out[i * 2 + 1] * (float)imgH;
-            face.landmarks[i].score = 1.0f;
-        }
-        face.detected   = true;
-        face.faceScore  = 1.0f;
-    } else if (outLen == kFaceLandmarkCount * 3) {
-        for (int i = 0; i < kFaceLandmarkCount; ++i) {
-            float x     = out[i * 3 + 0];
-            float y     = out[i * 3 + 1];
-            float s     = out[i * 3 + 2];
+            float x = out[i * 2 + 0];
+            float y = out[i * 2 + 1];
             face.landmarks[i].x     = x * (float)imgW;
             face.landmarks[i].y     = y * (float)imgH;
-            // 置信度过滤：低于 0.5 的点视为无效（score=0）
-            face.landmarks[i].score = (s < 0.5f) ? 0.0f : s;
+            face.landmarks[i].score = 1.0f;
+
+            minX = std::min(minX, x);
+            minY = std::min(minY, y);
+            maxX = std::max(maxX, x);
+            maxY = std::max(maxY, y);
+            numValidPoints++;
         }
-        face.detected   = true;
-        face.faceScore  = 1.0f;
+    } else if (outLen == kFaceLandmarkCount * 3) {
+        for (int i = 0; i < kFaceLandmarkCount; ++i) {
+            float x = out[i * 3 + 0];
+            float y = out[i * 3 + 1];
+            float s = out[i * 3 + 2];
+            face.landmarks[i].x     = x * (float)imgW;
+            face.landmarks[i].y     = y * (float)imgH;
+
+            if (s >= 0.5f) {
+                face.landmarks[i].score = s;
+                minX = std::min(minX, x);
+                minY = std::min(minY, y);
+                maxX = std::max(maxX, x);
+                maxY = std::max(maxY, y);
+                numValidPoints++;
+            } else {
+                face.landmarks[i].score = 0.0f;
+            }
+        }
     } else {
         LOGE("FaceLandmarkDetector: unexpected output length %d", outLen);
-        face.detected   = false;
+        face.detected = false;
+        return;
+    }
+
+    if (numValidPoints > 0) {
+        face.detected = true;
+        face.faceScore = 1.0f;
+        face.boundingBox[0] = minX;
+        face.boundingBox[1] = minY;
+        face.boundingBox[2] = maxX - minX;
+        face.boundingBox[3] = maxY - minY;
+    } else {
+        face.detected = false;
     }
 }
 

--- a/tests/test_ai_inference.cpp
+++ b/tests/test_ai_inference.cpp
@@ -41,51 +41,6 @@ static bool test_engine_construct() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 10: SegmentationFilter 参数读写与 Mode 切换
-// ---------------------------------------------------------------------------
-static bool test_segmentation_params() {
-    const std::string k = "SegmentationFilter parameters set/get and mode switch";
-    try {
-        SegmentationFilter sf(nullptr, nullptr);
-
-        // 1. Mode check
-        sf.setParameter("mode", static_cast<int>(SegmentationFilter::Mode::REPLACE_BG));
-        if (sf.getMode() != SegmentationFilter::Mode::REPLACE_BG) {
-            fail(k, "Mode set/get failed"); return false;
-        }
-
-        sf.setParameter("mode", static_cast<int>(SegmentationFilter::Mode::TRANSPARENT));
-        if (sf.getMode() != SegmentationFilter::Mode::TRANSPARENT) {
-            fail(k, "Mode switch failed"); return false;
-        }
-
-        // 2. blurStrength check
-        sf.setParameter("blurStrength", 25.0f);
-        if (sf.getBlurStrength() != 25.0f) {
-            fail(k, "blurStrength set/get failed"); return false;
-        }
-
-        // 3. bgColor check
-        uint32_t red = 0xFFFF0000u;
-        sf.setParameter("bgColor", red);
-        if (sf.getBgColor() != red) {
-            fail(k, "bgColor set/get failed"); return false;
-        }
-
-        // 4. bgImageTexture check
-        sf.setBgImageTexture(12345u);
-        if (sf.getBgImageTexture() != 12345u) {
-            fail(k, "bgImageTexture set/get failed"); return false;
-        }
-
-    } catch (...) {
-        fail(k, "unexpected exception"); return false;
-    }
-    pass(k);
-    return true;
-}
-
-// ---------------------------------------------------------------------------
 // Test 2: loadModel() 错误路径
 // ---------------------------------------------------------------------------
 static bool test_load_model_invalid() {
@@ -246,7 +201,117 @@ static bool test_decode_landmarks_invalid_len() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 10: BodyPoseDetector::decodeKeypoints
+// Test 11: decodeLandmarks 212 格式 BoundingBox
+// ---------------------------------------------------------------------------
+static bool test_decode_landmarks_212_bbox() {
+    const std::string k = "decodeLandmarks 212-float BoundingBox";
+    float mockOutput[212];
+    for (int i = 0; i < 106; ++i) {
+        // Range: [0.2, 0.2] to [0.8, 0.8]
+        mockOutput[i * 2 + 0] = 0.2f + 0.6f * static_cast<float>(i) / 105.0f;
+        mockOutput[i * 2 + 1] = 0.2f + 0.6f * static_cast<float>(i) / 105.0f;
+    }
+
+    FaceResult res;
+    FaceLandmarkDetector::decodeLandmarks(mockOutput, 212, 100, 100, res);
+
+    if (!res.detected) { fail(k, "should be detected"); return false; }
+    // bbox: [0.2, 0.2, 0.6, 0.6]
+    if (std::abs(res.boundingBox[0] - 0.2f) > 1e-5f ||
+        std::abs(res.boundingBox[1] - 0.2f) > 1e-5f ||
+        std::abs(res.boundingBox[2] - 0.6f) > 1e-5f ||
+        std::abs(res.boundingBox[3] - 0.6f) > 1e-5f) {
+        fail(k, "incorrect bounding box calculation"); return false;
+    }
+    pass(k);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: decodeLandmarks 318 格式 BoundingBox 与过滤
+// ---------------------------------------------------------------------------
+static bool test_decode_landmarks_318_bbox_filtering() {
+    const std::string k = "decodeLandmarks 318-float BoundingBox with filtering";
+    float mockOutput[318];
+    for (int i = 0; i < 106; ++i) {
+        mockOutput[i * 3 + 0] = 0.5f;
+        mockOutput[i * 3 + 1] = 0.5f;
+        mockOutput[i * 3 + 2] = 0.1f; // all low score initially
+    }
+
+    // Set two valid points to define bbox
+    mockOutput[10 * 3 + 0] = 0.3f; mockOutput[10 * 3 + 1] = 0.3f; mockOutput[10 * 3 + 2] = 0.9f;
+    mockOutput[20 * 3 + 0] = 0.7f; mockOutput[20 * 3 + 1] = 0.7f; mockOutput[20 * 3 + 2] = 0.9f;
+
+    FaceResult res;
+    FaceLandmarkDetector::decodeLandmarks(mockOutput, 318, 100, 100, res);
+
+    if (!res.detected) { fail(k, "should be detected"); return false; }
+    // bbox should be [0.3, 0.3, 0.4, 0.4], ignoring 0.5,0.5 points because they have 0.1 score
+    if (std::abs(res.boundingBox[0] - 0.3f) > 1e-5f ||
+        std::abs(res.boundingBox[1] - 0.3f) > 1e-5f ||
+        std::abs(res.boundingBox[2] - 0.4f) > 1e-5f ||
+        std::abs(res.boundingBox[3] - 0.4f) > 1e-5f) {
+        fail(k, "incorrect bounding box with filtering. Got [" +
+            std::to_string(res.boundingBox[0]) + "," + std::to_string(res.boundingBox[1]) + "]");
+        return false;
+    }
+    pass(k);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: decodeLandmarks 全部过滤
+// ---------------------------------------------------------------------------
+static bool test_decode_landmarks_all_filtered() {
+    const std::string k = "decodeLandmarks all points filtered";
+    float mockOutput[318];
+    for (int i = 0; i < 106; ++i) {
+        mockOutput[i * 3 + 0] = 0.5f;
+        mockOutput[i * 3 + 1] = 0.5f;
+        mockOutput[i * 3 + 2] = 0.4f; // all low score
+    }
+
+    FaceResult res;
+    res.detected = true;
+    FaceLandmarkDetector::decodeLandmarks(mockOutput, 318, 100, 100, res);
+
+    if (res.detected) { fail(k, "detected should be false when all points are filtered"); return false; }
+    pass(k);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test 14: decodeLandmarks 边界精度测试
+// ---------------------------------------------------------------------------
+static bool test_decode_landmarks_bbox_precision() {
+    const std::string k = "decodeLandmarks bbox precision (single point)";
+    float mockOutput[318];
+    for (int i = 0; i < 106; ++i) {
+        mockOutput[i * 3 + 0] = 0.0f;
+        mockOutput[i * 3 + 1] = 0.0f;
+        mockOutput[i * 3 + 2] = 0.0f;
+    }
+    mockOutput[50 * 3 + 0] = 0.123f;
+    mockOutput[50 * 3 + 1] = 0.456f;
+    mockOutput[50 * 3 + 2] = 1.0f;
+
+    FaceResult res;
+    FaceLandmarkDetector::decodeLandmarks(mockOutput, 318, 100, 100, res);
+
+    if (!res.detected) { fail(k, "should be detected"); return false; }
+    if (std::abs(res.boundingBox[0] - 0.123f) > 1e-6f ||
+        std::abs(res.boundingBox[1] - 0.456f) > 1e-6f ||
+        std::abs(res.boundingBox[2] - 0.0f) > 1e-6f ||
+        std::abs(res.boundingBox[3] - 0.0f) > 1e-6f) {
+        fail(k, "precision check failed"); return false;
+    }
+    pass(k);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test 15: BodyPoseDetector::decodeKeypoints
 // ---------------------------------------------------------------------------
 class BodyPoseDetectorTestAccessor : public BodyPoseDetector {
 public:
@@ -291,6 +356,51 @@ static bool test_body_pose_decode() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 16: SegmentationFilter 参数读写与 Mode 切换
+// ---------------------------------------------------------------------------
+static bool test_segmentation_params() {
+    const std::string k = "SegmentationFilter parameters set/get and mode switch";
+    try {
+        SegmentationFilter sf(nullptr, nullptr);
+
+        // 1. Mode check
+        sf.setParameter("mode", static_cast<int>(SegmentationFilter::Mode::REPLACE_BG));
+        if (sf.getMode() != SegmentationFilter::Mode::REPLACE_BG) {
+            fail(k, "Mode set/get failed"); return false;
+        }
+
+        sf.setParameter("mode", static_cast<int>(SegmentationFilter::Mode::TRANSPARENT));
+        if (sf.getMode() != SegmentationFilter::Mode::TRANSPARENT) {
+            fail(k, "Mode switch failed"); return false;
+        }
+
+        // 2. blurStrength check
+        sf.setParameter("blurStrength", 25.0f);
+        if (sf.getBlurStrength() != 25.0f) {
+            fail(k, "blurStrength set/get failed"); return false;
+        }
+
+        // 3. bgColor check
+        uint32_t red = 0xFFFF0000u;
+        sf.setParameter("bgColor", red);
+        if (sf.getBgColor() != red) {
+            fail(k, "bgColor set/get failed"); return false;
+        }
+
+        // 4. bgImageTexture check
+        sf.setBgImageTexture(12345u);
+        if (sf.getBgImageTexture() != 12345u) {
+            fail(k, "bgImageTexture set/get failed"); return false;
+        }
+
+    } catch (...) {
+        fail(k, "unexpected exception"); return false;
+    }
+    pass(k);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 int main() {
@@ -313,6 +423,12 @@ int main() {
     run(test_load_from_null_buffer());
     run(test_decode_landmarks_212());
     run(test_decode_landmarks_318_filtering());
+    run(test_decode_landmarks_invalid_len());
+    run(test_decode_landmarks_212_bbox());
+    run(test_decode_landmarks_318_bbox_filtering());
+    run(test_decode_landmarks_all_filtered());
+    run(test_decode_landmarks_bbox_precision());
+    run(test_body_pose_decode());
     run(test_segmentation_params());
 
     std::cout << "\nResult: " << passed << "/" << total << " passed\n";


### PR DESCRIPTION
This PR completes the post-processing logic for the FaceLandmarkDetector. 
It now correctly decodes raw TFLite outputs (supporting both 106x2 and 106x3 formats), denormalizes coordinates into pixel space, filters low-confidence points, and calculates a normalized bounding box for the detected face.
New unit tests ensure correctness across various scenarios including different output formats and point filtering.

Fixes #291

---
*PR created automatically by Jules for task [4885292288564890470](https://jules.google.com/task/4885292288564890470) started by @zx2121651*