### PR TITLE
Clip Core Enhancement: Bezier, EffectClip, and Time Remapping

### DIFF
--- a/core/include/timeline/Clip.h
+++ b/core/include/timeline/Clip.h
@@ -60,7 +60,8 @@ public:
         AUDIO,
         IMAGE,
         TEXT,    ///< 纯文字叠加层（SubtitleClip / 文字贴纸）
-        STICKER  ///< 贴纸 / GIF / 动效叠加层（StickerClip）
+        STICKER, ///< 贴纸 / GIF / 动效叠加层（StickerClip）
+        EFFECT   ///< 特效片段 (EffectClip)
     };
 
     Clip(const std::string& id, const std::string& sourcePath, MediaType type);
@@ -94,6 +95,14 @@ public:
     /** @brief 倒放开关。开启时 DecoderPool 将触发精确 Seek 路径（逐帧反向取帧）。 */
     void setReversed(bool reversed) { m_isReversed = reversed; }
     bool isReversed() const { return m_isReversed; }
+
+    // 时间重映射 (Time Remapping)
+    /** @brief 设置变速曲线上的点。时间为相对于 Clip 起点的相对时间。 */
+    void setSpeedCurvePoint(int64_t relativeTimeNs, float speed);
+    /** @brief 获取指定相对时间点的瞬时速度。 */
+    float getSpeedAtTime(int64_t relativeTimeNs) const;
+    /** @brief 将时间轴相对时间映射到源素材相对时间（考虑变速曲线积分）。 */
+    int64_t getRemappedTime(int64_t relativeTimeNs) const;
 
     // 空间变换
     void setTransform(float scale, float rotation, float transX, float transY);
@@ -256,6 +265,29 @@ private:
     // 数据结构：属性名 -> (相对时间戳 -> KeyframeEntry{value, easing})
     // std::map 自带按 Key (时间戳) 排序的特性，便于插值查找
     std::map<std::string, std::map<int64_t, KeyframeEntry>> m_keyframes;
+
+    // 时间重映射：相对时间 -> 瞬时速度
+    std::map<int64_t, float> m_speedCurve;
+};
+
+/**
+ * @brief 特效片段 (EffectClip)
+ */
+class EffectClip : public Clip {
+public:
+    EffectClip(const std::string& id, const std::string& effectType);
+
+    std::string getEffectType() const { return m_effectType; }
+    void setEffectType(const std::string& type) { m_effectType = type; }
+
+    float getIntensity(int64_t relativeTimeNs) const {
+        return getInterpolatedParam("intensity", relativeTimeNs, m_intensity);
+    }
+    void setIntensity(float intensity) { m_intensity = intensity; }
+
+private:
+    std::string m_effectType;
+    float m_intensity = 1.0f;
 };
 
 using ClipPtr = std::shared_ptr<Clip>;

--- a/core/src/timeline/Clip.cpp
+++ b/core/src/timeline/Clip.cpp
@@ -152,6 +152,71 @@ float Clip::evaluateBezier(float t, float cp1x, float cp1y, float cp2x, float cp
            (3.0f * cp1y * currentT);
 }
 
+// ---------------------------------------------------------------------------
+// 时间重映射 (Time Remapping)
+// ---------------------------------------------------------------------------
+void Clip::setSpeedCurvePoint(int64_t relativeTimeNs, float speed) {
+    m_speedCurve[relativeTimeNs] = speed;
+}
+
+float Clip::getSpeedAtTime(int64_t relativeTimeNs) const {
+    if (m_speedCurve.empty()) return m_speed;
+
+    auto itNext = m_speedCurve.lower_bound(relativeTimeNs);
+    if (itNext == m_speedCurve.begin()) return itNext->second;
+    if (itNext == m_speedCurve.end()) return std::prev(itNext)->second;
+
+    auto itPrev = std::prev(itNext);
+    int64_t t0 = itPrev->first;
+    int64_t t1 = itNext->first;
+    float   v0 = itPrev->second;
+    float   v1 = itNext->second;
+
+    float ratio = static_cast<float>(relativeTimeNs - t0) / static_cast<float>(t1 - t0);
+    return v0 + (v1 - v0) * ratio;
+}
+
+int64_t Clip::getRemappedTime(int64_t relativeTimeNs) const {
+    if (m_speedCurve.empty()) {
+        return static_cast<int64_t>(std::round(relativeTimeNs * static_cast<long double>(m_speed)));
+    }
+
+    long double totalSourceNs = 0;
+    int64_t lastT = 0;
+
+    for (auto const& [t, v] : m_speedCurve) {
+        if (t <= 0) {
+            lastT = t;
+            continue;
+        }
+        if (t > relativeTimeNs) break;
+
+        int64_t t0 = lastT;
+        int64_t t1 = t;
+        float   v0 = getSpeedAtTime(t0);
+        float   v1 = v;
+
+        // Integral of linear speed: v(u) = v0 + (v1-v0)*(u-t0)/(t1-t0)
+        // SourceTime = Integral(v(u) du) from t0 to t1 = (v0 + v1) / 2 * (t1 - t0)
+        totalSourceNs += static_cast<long double>(v0 + v1) * 0.5 * (t1 - t0);
+        lastT = t1;
+    }
+
+    if (lastT < relativeTimeNs) {
+        float v0 = getSpeedAtTime(lastT);
+        float v1 = getSpeedAtTime(relativeTimeNs);
+        totalSourceNs += static_cast<long double>(v0 + v1) * 0.5 * (relativeTimeNs - lastT);
+    }
+
+    return static_cast<int64_t>(std::round(totalSourceNs));
+}
+
+// ---------------------------------------------------------------------------
+// EffectClip
+// ---------------------------------------------------------------------------
+EffectClip::EffectClip(const std::string& id, const std::string& effectType)
+    : Clip(id, "", MediaType::EFFECT), m_effectType(effectType) {}
+
 } // namespace timeline
 } // namespace video
 } // namespace sdk

--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -408,6 +408,45 @@ void test_bezier_serialization() {
     std::cout << "test_bezier_serialization passed" << std::endl;
 }
 
+void test_effect_clip() {
+    auto effect = std::make_shared<EffectClip>("fx1", "blur");
+    assert(effect->getType() == Clip::MediaType::EFFECT);
+    assert(effect->getEffectType() == "blur");
+
+    // Static intensity
+    effect->setIntensity(0.8f);
+    assert(std::abs(effect->getIntensity(0) - 0.8f) < EPSILON);
+
+    // Keyframed intensity
+    effect->addKeyframe("intensity", 0, 0.0f);
+    effect->addKeyframe("intensity", 1000000000, 1.0f);
+    assert(std::abs(effect->getIntensity(500000000) - 0.5f) < EPSILON);
+
+    std::cout << "test_effect_clip passed" << std::endl;
+}
+
+void test_time_remapping() {
+    auto clip = std::make_shared<Clip>("c1", "v1.mp4", Clip::MediaType::VIDEO);
+
+    // 1. Linear constant speed (0.5x)
+    clip->setSpeedCurvePoint(0, 0.5f);
+    assert(std::abs(clip->getSpeedAtTime(500000000) - 0.5f) < EPSILON);
+    assert(clip->getRemappedTime(1000000000) == 500000000);
+
+    // 2. Variable speed: 0s(0.5x) -> 2s(2.0x)
+    // At 1s, speed should be 1.25x
+    clip->setSpeedCurvePoint(2000000000, 2.0f);
+    assert(std::abs(clip->getSpeedAtTime(1000000000) - 1.25f) < EPSILON);
+
+    // Integral from 0 to 1s:
+    // v(t) = 0.5 + (2.0 - 0.5) * t / 2.0 = 0.5 + 0.75 * t
+    // SourceTime(t) = 0.5t + 0.375 * t^2
+    // SourceTime(1s) = 0.5 * 1 + 0.375 * 1^2 = 0.875s = 875,000,000 ns
+    assert(clip->getRemappedTime(1000000000) == 875000000);
+
+    std::cout << "test_time_remapping passed" << std::endl;
+}
+
 int main() {
     test_timeline_basic_properties();
     test_clip_boundary_trim();
@@ -425,5 +464,7 @@ int main() {
     test_keyframe_interpolation();
     test_bezier_interpolation();
     test_bezier_serialization();
+    test_effect_clip();
+    test_time_remapping();
     return 0;
 }


### PR DESCRIPTION
This PR completes the core enhancement of the Clip class by adding support for Bezier interpolation, introducing a new EffectClip class for effect-specific tracks, and implementing a robust time remapping system using speed curve integration. 

Key changes:
1. **Bezier Interpolation**: Keyframes now support cubic Bezier easing using Newton's method for precise timing control.
2. **EffectClip**: A specialized Clip subclass for effects, featuring an 'effectType' and an 'intensity' parameter that supports keyframing.
3. **Time Remapping**: Added a speed curve mechanism that allows for variable playback speeds (e.g., speed ramps) by integrating the speed over time to map timeline positions to source media timestamps.
4. **Testing**: New test cases verify the mathematical correctness of Bezier interpolation (linear fallback), EffectClip property management, and time remapping (variable speed integration).

Fixes #294

---
*PR created automatically by Jules for task [1816413372167909575](https://jules.google.com/task/1816413372167909575) started by @zx2121651*