### PR TITLE
feat(dsr): 真正激活实时降级渲染并对齐多端配置

### DIFF
--- a/android/src/main/cpp/TimelineExporterBridge.cpp
+++ b/android/src/main/cpp/TimelineExporterBridge.cpp
@@ -61,10 +61,8 @@ Java_com_sdk_video_timeline_TimelineExporter_nativeExportAsync(JNIEnv *env, jobj
     if (!timelinePtr || !(*timelinePtr) || !wrapper || !wrapper->filterEngine) return -1;
 
     auto compositor = std::make_shared<Compositor>(*timelinePtr, wrapper->filterEngine);
-    // 将 RenderEngine 中待命的 DSR 配置注入 Compositor
-    if (wrapper->dsrEnabled) {
-        compositor->setDsrConfig(wrapper->pendingDsr);
-    }
+    // 强制离线导出关闭 DSR，保证最终画质，不使用预览期的降级配置
+    compositor->disableDsr();
 
     // 创建音频混音器（可选）：有平台解码器池时注入，无则静音导出
     {

--- a/core/include/FilterEngine.h
+++ b/core/include/FilterEngine.h
@@ -67,6 +67,12 @@ public:
     Result buildTimelinePipeline(std::shared_ptr<timeline::Timeline> timeline, std::shared_ptr<timeline::Compositor> compositor);
 
     /**
+     * @brief Configure Dynamic Resolution Scaling (DSR) for Timeline mode.
+     */
+    void setDsrConfig(float targetFps, float minScaleFactor = 0.5f, float maxScaleFactor = 1.0f);
+    void disableDsr();
+
+    /**
      * @brief Add a filter to the pipeline.
      * @note MUST be called on the Render thread as it triggers filter initialization.
      */

--- a/core/include/timeline/Compositor.h
+++ b/core/include/timeline/Compositor.h
@@ -92,7 +92,7 @@ private:
     // ---------------------------------------------------------------------------
     DsrConfig         m_dsrConfig;
     float             m_dsrScale     = 1.0f;  // 当前渲染倍率，[minScale, maxScale]
-    bool              m_dsrEnabled   = false;
+    bool              m_dsrEnabled   = true;
     std::deque<float> m_dsrFrameTimes;         // 近 N 帧帧时间（ms）
 
     void updateDsrScale(float frameTimeMs);

--- a/core/src/FilterEngine.cpp
+++ b/core/src/FilterEngine.cpp
@@ -297,6 +297,22 @@ Result FilterEngine::buildTimelinePipeline(std::shared_ptr<timeline::Timeline> t
     return res;
 }
 
+void FilterEngine::setDsrConfig(float targetFps, float minScaleFactor, float maxScaleFactor) {
+    if (auto comp = m_compositor.lock()) {
+        timeline::DsrConfig cfg;
+        cfg.targetFps = targetFps;
+        cfg.minScaleFactor = minScaleFactor;
+        cfg.maxScaleFactor = maxScaleFactor;
+        comp->setDsrConfig(cfg);
+    }
+}
+
+void FilterEngine::disableDsr() {
+    if (auto comp = m_compositor.lock()) {
+        comp->disableDsr();
+    }
+}
+
 Result FilterEngine::rebuildGraph(std::shared_ptr<PipelineNode> inputNode) {
     // Transactional Graph Rebuild:
     // We build the new graph in isolation and only commit it to the engine state

--- a/core/src/timeline/Compositor.cpp
+++ b/core/src/timeline/Compositor.cpp
@@ -47,7 +47,14 @@ const char* Compositor::s_quadVertSrc = R"(#version 300 es
 )";
 
 Compositor::Compositor(std::shared_ptr<Timeline> timeline, std::shared_ptr<FilterEngine> engine)
-    : m_timeline(timeline), m_filterEngine(engine), m_decoderPool(nullptr) {}
+    : m_timeline(timeline), m_filterEngine(engine), m_decoderPool(nullptr) {
+    // 默认开启保守 DSR 策略防卡顿
+    m_dsrEnabled = true;
+    m_dsrConfig.targetFps = 30.0f;
+    m_dsrConfig.minScaleFactor = 0.7f;
+    m_dsrConfig.maxScaleFactor = 1.0f;
+    m_dsrConfig.sampleWindow = 6;
+}
 
 Compositor::~Compositor() {
 #ifdef __ANDROID__

--- a/finish.sh
+++ b/finish.sh
@@ -1,0 +1,1 @@
+python3 -c "import urllib.request, json; urllib.request.urlopen(urllib.request.Request('http://localhost:8080/submit', data=json.dumps({'branch_name': 'feature/dsr-optimization'}).encode('utf-8'), headers={'Content-Type': 'application/json'}))"

--- a/ios/Classes/FilterEngine.swift
+++ b/ios/Classes/FilterEngine.swift
@@ -66,6 +66,14 @@ import OpenGLES
     @objc public func recordDroppedFrame() {
         wrapper.recordDroppedFrame()
     }
+
+    @objc public func setDsrConfig(targetFps: Float, minScale: Float, maxScale: Float) {
+        wrapper.setDsrConfigWithTargetFps(targetFps, minScale: minScale, maxScale: maxScale)
+    }
+
+    @objc public func disableDsr() {
+        wrapper.disableDsr()
+    }
     // Free resources
     @objc public func releaseEngine() {
         wrapper.releaseResources()

--- a/ios/Classes/FilterEngineWrapper.h
+++ b/ios/Classes/FilterEngineWrapper.h
@@ -28,6 +28,9 @@ typedef NS_ENUM(NSInteger, IOSFilterType) {
 
 - (NSArray<NSNumber *> *)getPerformanceMetrics;
 - (void)recordDroppedFrame;
+- (void)setDsrConfigWithTargetFps:(float)fps minScale:(float)minScale maxScale:(float)maxScale;
+- (void)disableDsr;
+
 - (void)releaseResources;
 
 @end

--- a/ios/Classes/FilterEngineWrapper.mm
+++ b/ios/Classes/FilterEngineWrapper.mm
@@ -256,6 +256,18 @@ using namespace sdk::video;
     return 0;
 }
 
+- (void)setDsrConfigWithTargetFps:(float)fps minScale:(float)minScale maxScale:(float)maxScale {
+    if (engine) {
+        engine->setDsrConfig(fps, minScale, maxScale);
+    }
+}
+
+- (void)disableDsr {
+    if (engine) {
+        engine->disableDsr();
+    }
+}
+
 - (void)releaseResources {
     if (engine) {
         engine->release();

--- a/ios/Classes/VideoFilterManager.swift
+++ b/ios/Classes/VideoFilterManager.swift
@@ -210,6 +210,14 @@ public actor VideoFilterManager {
         engine.recordDroppedFrame()
     }
 
+    public func setDsrConfig(targetFps: Float, minScale: Float = 0.5, maxScale: Float = 1.0) {
+        engine.setDsrConfig(targetFps: targetFps, minScale: minScale, maxScale: maxScale)
+    }
+
+    public func disableDsr() {
+        engine.disableDsr()
+    }
+
     public func release() {
         if let encoder = videoEncoder {
             encoder.stopRecording(isFallback: false)


### PR DESCRIPTION
1. 在 Compositor 中默认开启保守的 DSR 策略（30fps, 0.7x~1.0x），实现开箱即用的防卡顿能力。
2. 强制 TimelineExporter 离线导出时禁用 DSR，确保导出视频满血画质。
3. 在 iOS FilterEngine 和 VideoFilterManager 侧暴露 setDsrConfig 与 disableDsr API，实现双端能力对齐。

---
*PR created automatically by Jules for task [7929958929999329503](https://jules.google.com/task/7929958929999329503) started by @zx2121651*